### PR TITLE
Archaic-Wrapper rule and visitTask capabilities

### DIFF
--- a/src/integTest/java/com/netflix/nebula/lint/plugin/GradleLintPluginSpec.groovy
+++ b/src/integTest/java/com/netflix/nebula/lint/plugin/GradleLintPluginSpec.groovy
@@ -281,4 +281,30 @@ class GradleLintPluginSpec extends TestKitSpecification {
         console.any { it.contains('dependency-tuple') }
         new File(projectDir, "build/reports/gradleLint/${moduleName}.html").exists()
     }
+
+    def 'test wrapper rule on a single module project'() {
+        when:
+        buildFile << """
+            plugins {
+                id 'nebula.lint'
+                id 'java'
+            }
+
+            gradleLint.rules = ['archaic-wrapper']
+
+            task wrapper(type: Wrapper){
+                gradleVersion = '0.1'
+            }
+        """
+
+        then:
+        def results = runTasksSuccessfully('lintGradle')
+
+        when:
+        def console = results.output.readLines()
+
+        then:
+        console.findAll { it.startsWith('warning') }.size() == 1
+        console.any { it.contains('archaic-wrapper') }
+    }
 }

--- a/src/main/groovy/com/netflix/nebula/lint/rule/GradleAstVisitor.groovy
+++ b/src/main/groovy/com/netflix/nebula/lint/rule/GradleAstVisitor.groovy
@@ -62,4 +62,6 @@ interface GradleAstVisitor {
     ASTNode bookmark(String label)
 
     void visitDependencies(MethodCallExpression call)
+
+    void visitTask(MethodCallExpression call, String name, Map<String, String> args)
 }

--- a/src/main/groovy/com/netflix/nebula/lint/rule/wrapper/ArchaicWrapperRule.groovy
+++ b/src/main/groovy/com/netflix/nebula/lint/rule/wrapper/ArchaicWrapperRule.groovy
@@ -1,0 +1,133 @@
+/**
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.nebula.lint.rule.wrapper
+
+import com.netflix.nebula.lint.rule.GradleLintRule
+import com.netflix.nebula.lint.rule.GradleModelAware
+import groovy.json.JsonSlurper
+import org.codehaus.groovy.ast.ClassNode
+import org.codehaus.groovy.ast.expr.MethodCallExpression
+import org.codehaus.groovy.ast.stmt.ExpressionStatement
+import org.gradle.util.GradleVersion
+
+import java.util.regex.Matcher
+import java.util.regex.Pattern
+
+/**
+ * Created by Boaz Jan on 17/05/16.
+ */
+class ArchaicWrapperRule extends GradleLintRule implements GradleModelAware {
+    private static
+    final Pattern VERSION_PATTERN = Pattern.compile("((\\d+)\\.(\\d+)+)(-(\\p{Alpha}+)-(\\d+[a-z]?))?(-(\\d{14}([-+]\\d{4})?))?");
+
+    private GradleVersion latestGradleVersion = null
+    private GradleVersion wrapperGradleVersion = null
+    private boolean hasWrapperTask = false
+    private boolean hasGradleVersionProperty = false
+
+    int majorThreshold = 0
+    int minorThreshold = 2
+    boolean offline = false
+
+    @Override
+    String getDescription() {
+        return "don't use archaic wrapper versions"
+    }
+
+    @Override
+    protected void beforeApplyTo() {
+        if (!offline) {
+            try {
+                String gradleCurrentVersion = new URL('http://services.gradle.org/versions/current').text
+                def json = new JsonSlurper().parseText(gradleCurrentVersion)
+                latestGradleVersion = GradleVersion.version(json.version)
+            } catch (Exception ex) {
+                //TODO: add info log
+            }
+        }
+        super.beforeApplyTo()
+    }
+
+    @Override
+    void visitTask(MethodCallExpression call, String name, Map<String, String> args) {
+        if (args.containsKey('type') && args.get('type') == 'Wrapper') {
+            hasWrapperTask = true
+            bookmark('wrapperTask', call)
+        }
+    }
+
+    @Override
+    void visitExtensionProperty(ExpressionStatement expression, String extension, String prop, String value) {
+        if (extension == 'wrapper' && prop == 'gradleVersion') {
+            hasGradleVersionProperty = true
+            wrapperGradleVersion = GradleVersion.version(value)
+            bookmark('gradleVersionExpression', expression)
+        }
+    }
+
+    @Override
+    protected void visitClassComplete(ClassNode node) {
+        if (!hasWrapperTask && !hasGradleVersionProperty) {
+            return
+        }
+        if (hasWrapperTask && !hasGradleVersionProperty) {
+            addBuildLintViolation("The wrapper task is not properly configured, the 'gradleVersion' is missing.")
+            //TODO: auto fix?
+            return
+        }
+        def versionExpression = bookmark('gradleVersionExpression')
+
+        GradleVersion executionGradleVersion = GradleVersion.version(project.gradle.getGradleVersion())
+        if (wrapperGradleVersion > executionGradleVersion) {
+            addBuildLintViolation("This build was executed with a Gradle version [$executionGradleVersion] older then the one defined by the build's wrapper [$wrapperGradleVersion]")
+            return
+        }
+
+        String versionTitle
+        GradleVersion latestKnownGradleVersion
+        if (latestGradleVersion == null) {
+            // In case we we're unable to fetch the latest version from the web
+            // this will make sure to gracefully continue with the executed gradle
+            // in case this is the wrapper then nothing will happen.
+            // If it's not the wrapper and of significantly newer version, we will still warn
+            versionTitle = 'execution'
+            latestKnownGradleVersion = executionGradleVersion
+        } else {
+            versionTitle = 'latest'
+            latestKnownGradleVersion = latestGradleVersion
+        }
+
+        if (latestKnownGradleVersion > wrapperGradleVersion) {
+            def latestVersionParts = splitVersionParts(latestKnownGradleVersion)
+            def wrapperVersionParts = splitVersionParts(wrapperGradleVersion)
+            if (latestVersionParts['major'] - wrapperVersionParts['major'] > majorThreshold) {
+                addBuildLintViolation("The build's wrapper is more then $majorThreshold major versions behind the ${versionTitle} Gradle version")
+                        .replaceWith(versionExpression, "gradleVersion = '${latestKnownGradleVersion.getVersion()}'")
+            } else if (latestVersionParts['minor'] - wrapperVersionParts['minor'] > minorThreshold) {
+                addBuildLintViolation("The build's wrapper is more then $minorThreshold minor versions behind the ${versionTitle} Gradle version")
+                        .replaceWith(versionExpression, "gradleVersion = '${latestKnownGradleVersion.getVersion()}'")
+            }
+        }
+    }
+
+    private def Map splitVersionParts(GradleVersion version) {
+        Matcher matcher = VERSION_PATTERN.matcher(version.getVersion());
+        if (!matcher.matches()) {
+            throw new IllegalArgumentException("'${version.getVersion()}' is not a valid Gradle version string (examples: '1.0', '1.0-rc-1')")
+        }
+        return [major: Integer.parseInt(matcher.group(2)), minor: Integer.parseInt(matcher.group(3))]
+    }
+}

--- a/src/main/resources/META-INF/lint-rules/archaic-wrapper.properties
+++ b/src/main/resources/META-INF/lint-rules/archaic-wrapper.properties
@@ -1,0 +1,17 @@
+#
+# Copyright 2016 the original author or authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+implementation-class=com.netflix.nebula.lint.rule.wrapper.ArchaicWrapperRule

--- a/src/test/groovy/com/netflix/nebula/lint/rule/wrapper/ArchaicWrapperRuleSpec.groovy
+++ b/src/test/groovy/com/netflix/nebula/lint/rule/wrapper/ArchaicWrapperRuleSpec.groovy
@@ -1,0 +1,193 @@
+/**
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.nebula.lint.rule.wrapper
+
+import com.netflix.nebula.lint.rule.test.AbstractRuleSpec
+import org.gradle.util.GradleVersion
+
+/**
+ * Created by Boaz Jan on 20/05/16.
+ */
+class ArchaicWrapperRuleSpec extends AbstractRuleSpec {
+
+    def 'wrapper without a configuration is a violation'() {
+        when:
+        project = new WrapperProjectBuilder().createProject(canonicalName, ourProjectDir)
+        project.gradle.version = GradleVersion.version('2.13')
+        project.buildFile << """
+            task wrapper(type: Wrapper)
+        """
+
+        def rule = new ArchaicWrapperRule()
+        rule.project = project
+        rule.offline = true
+        rule.majorThreshold = 0
+        rule.minorThreshold = 2
+        def results = runRulesAgainst(rule)
+
+        then:
+        results.violations.size() == 1
+    }
+
+    def 'wrapper without gradleVersion in its configuration is a violation'() {
+        when:
+        project = new WrapperProjectBuilder().createProject(canonicalName, ourProjectDir)
+        project.gradle.version = GradleVersion.version('2.13')
+        project.buildFile << """
+            task wrapper(type: Wrapper) {
+                archiveBase = PathBase.GRADLE_USER_HOME
+            }
+        """
+
+        def rule = new ArchaicWrapperRule()
+        rule.project = project
+        rule.offline = true
+        rule.majorThreshold = 0
+        rule.minorThreshold = 2
+        def results = runRulesAgainst(rule)
+
+        then:
+        results.violations.size() == 1
+    }
+
+    def 'separately configured wrapper is not a violation'() {
+        when:
+        project = new WrapperProjectBuilder().createProject(canonicalName, ourProjectDir)
+        project.gradle.version = GradleVersion.version('2.13')
+        project.buildFile << """
+            task wrapper(type: Wrapper)
+            wrapper {
+               gradleVersion = '2.13'
+            }
+        """
+
+        def rule = new ArchaicWrapperRule()
+        rule.project = project
+        rule.offline = true
+        rule.majorThreshold = 0
+        rule.minorThreshold = 2
+        def results = runRulesAgainst(rule)
+
+        then:
+        results.violations.size() == 0
+    }
+
+
+
+    def 'wrapper defined with up to date version is not a violation'() {
+        when:
+        project = new WrapperProjectBuilder().createProject(canonicalName, ourProjectDir)
+        project.gradle.version = GradleVersion.version('2.13')
+        project.buildFile << """
+            task wrapper(type: Wrapper) {
+               gradleVersion = '2.13'
+            }
+        """
+
+        def rule = new ArchaicWrapperRule()
+        rule.project = project
+        rule.offline = true
+        rule.majorThreshold = 0
+        rule.minorThreshold = 2
+        def results = runRulesAgainst(rule)
+
+        then:
+        results.violations.size() == 0
+    }
+
+    def 'wrapper defined with a version within the threshold is not a violation'() {
+        when:
+        project = new WrapperProjectBuilder().createProject(canonicalName, ourProjectDir)
+        project.gradle.version = GradleVersion.version('2.13')
+        project.buildFile << """
+            task wrapper(type: Wrapper) {
+               gradleVersion = '2.11'
+            }
+        """
+
+        def rule = new ArchaicWrapperRule()
+        rule.project = project
+        rule.offline = true
+        rule.majorThreshold = 0
+        rule.minorThreshold = 2
+        def results = runRulesAgainst(rule)
+
+        then:
+        results.violations.size() == 0
+    }
+
+    def 'using a gradle executable which is older then the wrapper defined is a violation'() {
+        when:
+        project = new WrapperProjectBuilder().createProject(canonicalName, ourProjectDir)
+        project.gradle.version = GradleVersion.version('2.0')
+        project.buildFile << """
+            task wrapper(type: Wrapper) {
+               gradleVersion = '2.13'
+            }
+        """
+
+        def rule = new ArchaicWrapperRule()
+        rule.project = project
+        rule.offline = true
+        rule.majorThreshold = 0
+        rule.minorThreshold = 2
+        def results = runRulesAgainst(rule)
+
+        then:
+        results.violations.size() == 1
+    }
+
+    def 'wrapper defined with an old major version is a violation'() {
+        when:
+        project = new WrapperProjectBuilder().createProject(canonicalName, ourProjectDir)
+        project.gradle.version = GradleVersion.version('2.0')
+        project.buildFile << """
+            task wrapper(type: Wrapper) {
+               gradleVersion = '1.0'
+            }
+        """
+
+        def rule = new ArchaicWrapperRule()
+        rule.project = project
+        rule.offline = true
+        rule.majorThreshold = 0
+        def results = runRulesAgainst(rule)
+
+        then:
+        results.violations.size() == 1
+    }
+
+    def 'wrapper defined with an old minor version is a violation'() {
+        when:
+        project = new WrapperProjectBuilder().createProject(canonicalName, ourProjectDir)
+        project.gradle.version = GradleVersion.version('2.3')
+        project.buildFile << """
+            task wrapper(type: Wrapper) {
+               gradleVersion = '2.0'
+            }
+        """
+
+        def rule = new ArchaicWrapperRule()
+        rule.project = project
+        rule.offline = true
+        rule.majorThreshold = 0
+        rule.minorThreshold = 2
+        def results = runRulesAgainst(rule)
+
+        then:
+        results.violations.size() == 1
+    }
+}

--- a/src/test/groovy/com/netflix/nebula/lint/rule/wrapper/CustomVersionGradle.groovy
+++ b/src/test/groovy/com/netflix/nebula/lint/rule/wrapper/CustomVersionGradle.groovy
@@ -1,0 +1,38 @@
+/**
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.nebula.lint.rule.wrapper
+
+import org.gradle.StartParameter
+import org.gradle.api.invocation.Gradle
+import org.gradle.internal.service.scopes.ServiceRegistryFactory
+import org.gradle.invocation.DefaultGradle
+import org.gradle.util.GradleVersion
+
+/**
+ * Created by Boaz Jan on 22/05/16.
+ */
+class CustomVersionGradle extends DefaultGradle {
+    GradleVersion version = GradleVersion.current()
+
+    public CustomVersionGradle(Gradle parent, StartParameter startParameter, ServiceRegistryFactory parentRegistry) {
+        super(parent, startParameter, parentRegistry)
+    }
+
+    @Override
+    String getGradleVersion() {
+        return version.getVersion()
+    }
+}

--- a/src/test/groovy/com/netflix/nebula/lint/rule/wrapper/WrapperProjectBuilder.java
+++ b/src/test/groovy/com/netflix/nebula/lint/rule/wrapper/WrapperProjectBuilder.java
@@ -1,0 +1,102 @@
+/**
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.nebula.lint.rule.wrapper;
+
+import org.gradle.StartParameter;
+import org.gradle.api.Project;
+import org.gradle.api.internal.AsmBackedClassGenerator;
+import org.gradle.api.internal.GradleInternal;
+import org.gradle.api.internal.file.FileResolver;
+import org.gradle.api.internal.file.TemporaryFileProvider;
+import org.gradle.api.internal.file.TmpDirTemporaryFileProvider;
+import org.gradle.api.internal.initialization.ClassLoaderScope;
+import org.gradle.api.internal.project.IProjectFactory;
+import org.gradle.api.internal.project.ProjectInternal;
+import org.gradle.initialization.DefaultProjectDescriptor;
+import org.gradle.initialization.DefaultProjectDescriptorRegistry;
+import org.gradle.internal.nativeintegration.services.NativeServices;
+import org.gradle.internal.service.ServiceRegistry;
+import org.gradle.internal.service.ServiceRegistryBuilder;
+import org.gradle.internal.service.scopes.ServiceRegistryFactory;
+import org.gradle.logging.LoggingServiceRegistry;
+import org.gradle.testfixtures.internal.TestBuildScopeServices;
+import org.gradle.testfixtures.internal.TestGlobalScopeServices;
+import org.gradle.util.GFileUtils;
+
+import java.io.File;
+
+/**
+ * Created by Boaz Jan on 22/05/16.
+ *
+ * A duplication of Gradle's ProjectBuilderImpl, but instead of using the DefaultGradle - use our custom gradle
+ * that allows us to override the internal version. With this capability we can test various version related rules
+ * with significantly more control as it comes to test parameters and outcome predictability
+ */
+public class WrapperProjectBuilder {
+    private static ServiceRegistry globalServices;
+    private static final AsmBackedClassGenerator CLASS_GENERATOR = new AsmBackedClassGenerator();
+
+    public Project createProject(String name, File inputProjectDir) {
+        File projectDir = prepareProjectDir(inputProjectDir);
+
+        final File homeDir = new File(projectDir, "gradleHome");
+
+        StartParameter startParameter = new StartParameter();
+        File userHomeDir = new File(projectDir, "userHome");
+        startParameter.setGradleUserHomeDir(userHomeDir);
+
+        NativeServices.initialize(userHomeDir);
+
+        ServiceRegistry topLevelRegistry = new TestBuildScopeServices(getGlobalServices(), startParameter, homeDir);
+        GradleInternal gradle = CLASS_GENERATOR.newInstance(CustomVersionGradle.class, null, startParameter, topLevelRegistry.get(ServiceRegistryFactory.class));
+
+        DefaultProjectDescriptor projectDescriptor = new DefaultProjectDescriptor(null, name, projectDir, new DefaultProjectDescriptorRegistry(),
+                topLevelRegistry.get(FileResolver.class));
+        ClassLoaderScope baseScope = gradle.getClassLoaderScope();
+        ClassLoaderScope rootProjectScope = baseScope.createChild("root-project");
+        ProjectInternal project = topLevelRegistry.get(IProjectFactory.class).createProject(projectDescriptor, null, gradle, rootProjectScope, baseScope);
+
+        gradle.setRootProject(project);
+        gradle.setDefaultProject(project);
+
+        return project;
+    }
+
+    private ServiceRegistry getGlobalServices() {
+        if (globalServices == null) {
+            globalServices = ServiceRegistryBuilder
+                    .builder()
+                    .displayName("global services")
+                    .parent(LoggingServiceRegistry.newNestedLogging())
+                    .parent(NativeServices.getInstance())
+                    .provider(new TestGlobalScopeServices())
+                    .build();
+        }
+        return globalServices;
+    }
+
+    public File prepareProjectDir(File projectDir) {
+        if (projectDir == null) {
+            TemporaryFileProvider temporaryFileProvider = new TmpDirTemporaryFileProvider();
+            projectDir = temporaryFileProvider.createTemporaryDirectory("gradle", "projectDir");
+            // TODO deleteOnExit won't clean up non-empty directories (and it leaks memory for long-running processes).
+            projectDir.deleteOnExit();
+        } else {
+            projectDir = GFileUtils.canonicalise(projectDir);
+        }
+        return projectDir;
+    }
+}


### PR DESCRIPTION
In the rule wish list and you mentioned the wrapper rule which was (and still is) a pain point for me whenever a project leaves it's early stages.
So here is my initial attempt at creating the archaic-wrapper rule for which I had to expand the AST visitor to recognize task declarations of various forms (and also do some  workarounds with the test framework to predictably test this rule).
I'd appreciate any comment, would love to see this get in to the project.

Added visitTask to the AST visitor to be invoked for every task definition.
Created the archaic-wrapper rule, supports defining a threshold for the major version
and the minor version separately - defaults to 0 for major and 2 for minor.
A task for later commits is to design a way to configure a rule from within
the linted build.