### PR TITLE
Add support for plugins and buildscript blocks

### DIFF
--- a/src/main/groovy/com/netflix/nebula/lint/rule/GradleAstVisitor.groovy
+++ b/src/main/groovy/com/netflix/nebula/lint/rule/GradleAstVisitor.groovy
@@ -25,6 +25,8 @@ interface GradleAstVisitor {
 
     void visitGradleDependency(MethodCallExpression call, String conf, GradleDependency dep)
 
+    void visitGradlePlugin(MethodCallExpression call, String conf, GradlePlugin plugin)
+
     void visitConfigurationExclude(MethodCallExpression call, String conf, GradleDependency exclude)
 
     /**
@@ -62,6 +64,8 @@ interface GradleAstVisitor {
     ASTNode bookmark(String label)
 
     void visitDependencies(MethodCallExpression call)
+
+    void visitPlugins(MethodCallExpression call)
 
     void visitTask(MethodCallExpression call, String name, Map<String, String> args)
 }

--- a/src/main/groovy/com/netflix/nebula/lint/rule/GradleAstVisitor.groovy
+++ b/src/main/groovy/com/netflix/nebula/lint/rule/GradleAstVisitor.groovy
@@ -68,4 +68,6 @@ interface GradleAstVisitor {
     void visitPlugins(MethodCallExpression call)
 
     void visitTask(MethodCallExpression call, String name, Map<String, String> args)
+
+    void visitBuildscript(MethodCallExpression call)
 }

--- a/src/main/groovy/com/netflix/nebula/lint/rule/GradlePlugin.groovy
+++ b/src/main/groovy/com/netflix/nebula/lint/rule/GradlePlugin.groovy
@@ -1,0 +1,8 @@
+package com.netflix.nebula.lint.rule
+
+import groovy.transform.Canonical
+
+@Canonical
+class GradlePlugin {
+    String id
+}

--- a/src/main/groovy/com/netflix/nebula/lint/rule/rename/PluginRenamedRule.groovy
+++ b/src/main/groovy/com/netflix/nebula/lint/rule/rename/PluginRenamedRule.groovy
@@ -17,6 +17,7 @@
 package com.netflix.nebula.lint.rule.rename
 
 import com.netflix.nebula.lint.rule.GradleLintRule
+import com.netflix.nebula.lint.rule.GradlePlugin
 import groovy.transform.Canonical
 import org.codehaus.groovy.ast.expr.MethodCallExpression
 
@@ -36,6 +37,14 @@ class PluginRenamedRule extends GradleLintRule {
             addBuildLintViolation("plugin $deprecatedPluginName has been renamed to $pluginName", call)
                 .replaceWith(call, "apply plugin: '$pluginName'")
 
+        }
+    }
+
+    @Override
+    void visitGradlePlugin(MethodCallExpression call, String conf, GradlePlugin plugin) {
+        if (plugin.id == deprecatedPluginName) {
+            addBuildLintViolation("plugin $deprecatedPluginName has been renamed to $pluginName", call)
+                .replaceWith(call, "id '$pluginName'")
         }
     }
 }

--- a/src/test/groovy/com/netflix/nebula/lint/rule/GradleLintRuleSpec.groovy
+++ b/src/test/groovy/com/netflix/nebula/lint/rule/GradleLintRuleSpec.groovy
@@ -53,6 +53,29 @@ class GradleLintRuleSpec extends AbstractRuleSpec {
         pluginCount == 1
     }
 
+    def 'visit `plugins`'() {
+        when:
+        project.buildFile << """
+            plugins {
+             id 'java'
+            }
+        """
+
+        def pluginCount = 0
+
+        runRulesAgainst(new GradleLintRule() {
+            String description = 'test'
+
+            @Override
+            void visitGradlePlugin(MethodCallExpression call, String conf, GradlePlugin plugin) {
+                pluginCount++
+            }
+        })
+
+        then:
+        pluginCount == 1
+    }
+
     abstract class GradleProjectLintRule extends GradleLintRule implements GradleModelAware {}
 
     def 'visit `task`'() {

--- a/src/test/groovy/com/netflix/nebula/lint/rule/GradleLintRuleSpec.groovy
+++ b/src/test/groovy/com/netflix/nebula/lint/rule/GradleLintRuleSpec.groovy
@@ -76,6 +76,35 @@ class GradleLintRuleSpec extends AbstractRuleSpec {
         pluginCount == 1
     }
 
+    def 'visit `buildScript`'() {
+        when:
+        project.buildFile << """
+            buildscript {
+                repositories {
+                    maven { url 'https://plugins.gradle.org/m2/' }
+                }
+
+                dependencies {
+                    classpath 'com.gradle:build-scan-plugin:1.1.1'
+                }
+            }
+        """
+
+        def dependenciesCount = 0
+
+        runRulesAgainst(new GradleLintRule() {
+            String description = 'test'
+
+            @Override
+            void visitGradleDependency(MethodCallExpression call, String conf, GradleDependency dep) {
+                dependenciesCount++
+            }
+        })
+
+        then:
+        dependenciesCount == 1
+    }
+
     abstract class GradleProjectLintRule extends GradleLintRule implements GradleModelAware {}
 
     def 'visit `task`'() {

--- a/src/test/groovy/com/netflix/nebula/lint/rule/rename/PluginRenamedRuleSpec.groovy
+++ b/src/test/groovy/com/netflix/nebula/lint/rule/rename/PluginRenamedRuleSpec.groovy
@@ -31,6 +31,19 @@ class PluginRenamedRuleSpec extends AbstractRuleSpec {
         results.violations.size() == 1
     }
 
+    def 'deprecated plugin names (using plugins DSL) are recorded as violations'() {
+        when:
+        project.buildFile << """
+            plugins {
+             id 'ye-olde-plugin'
+            }
+        """
+
+        def results = runRulesAgainst(new PluginRenamedRule('ye-olde-plugin', 'shiny-new-plugin'))
+
+        then:
+        results.violations.size() == 1
+    }
     def 'deprecated plugin names are replaced with new names'() {
         when:
         project.buildFile << """


### PR DESCRIPTION
This PR offers support to the [plugins DSL](https://docs.gradle.org/current/userguide/plugins.html#sec:plugins_block) and [buildscript block](https://docs.gradle.org/current/javadoc/org/gradle/api/initialization/dsl/ScriptHandler.html).

Regarding `plugins` block. Creating a [GradlePlugin](https://github.com/felipefzdz/gradle-lint-plugin/blob/88474126ba0d2c17482c0ee551a68419f04ae6b8/src/main/groovy/com/netflix/nebula/lint/rule/GradlePlugin.groovy) pojo  might be an overkill, but I favoured it because of extensibility and type safety. The only existing rule that needed some rework was `PluginRenamedRule`.

About `buildscript` block. We're planning to use this block to autofix the absence of a missing plugin. Figuring out if the existing repositories are enough for the missing plugin is quite complicated, so for now the idea will be just adding the plugin dependency. Providing a visitor around repositories is not trivial, so those are the reasons about why I didn't include repository handling on the `buildscript` block.
