### PR TITLE
Regression in v6.0.0 refactoring

### DIFF
--- a/src/main/groovy/com/netflix/nebula/lint/GradleLintInfoBrokerAction.groovy
+++ b/src/main/groovy/com/netflix/nebula/lint/GradleLintInfoBrokerAction.groovy
@@ -27,7 +27,7 @@ class GradleLintInfoBrokerAction extends GradleLintViolationAction {
 
     LintReportItem buildReportItem(GradleViolation v) {
         def buildFilePath = project.rootDir.toURI().relativize(v.file.toURI()).toString()
-        new LintReportItem(buildFilePath, v.rule.ruleId as String, v.level.toString(),
+        new LintReportItem(buildFilePath, v.rule.ruleId as String, v.rule.getPriority() as String,
                 v.lineNumber ?: -1, v.sourceLine ?: 'unspecified', v.message ?: "")
     }
 }


### PR DESCRIPTION
I'm not 100% sure if this fix keeps the same semantics as it used to be. Maybe there should be the same mapping to warn, error etc (level Enum options) . But at least in our case the "duplicate-dependency-class" rule crashed lintGradle task when there were validation errors. I don't have more time to think about it right now, but I'm certain that there could be cleaner fix for this bug.