### PR TITLE
If direct call to lintGradle or fixGradleLint or fixLintGradle call a…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 build/
 .gradle
 gradle.properties
+.idea/

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ To apply this plugin:
     
     buildscript { repositories { jcenter() } }
     plugins {
-      id 'nebula.lint' version '6.1.4'
+      id 'nebula.lint' version '6.2.0'
     }
     
 *Important:* For now, in a multi-module build you **must** apply lint to the root project, at a minimum.
@@ -51,7 +51,7 @@ For multimodule projects, we recommend applying the plugin in an allprojects blo
 
 ## License
 
-Copyright 2015-2016 Netflix, Inc.
+Copyright 2015-2017 Netflix, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/integTest/java/com/netflix/nebula/lint/plugin/GradleLintPluginSpec.groovy
+++ b/src/integTest/java/com/netflix/nebula/lint/plugin/GradleLintPluginSpec.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016 Netflix, Inc.
+ * Copyright 2015-2017 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,10 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.netflix.nebula.lint.plugin
 
 import com.netflix.nebula.lint.TestKitSpecification
+import org.gradle.testkit.runner.TaskOutcome
 import spock.lang.Issue
 import spock.lang.Unroll
 
@@ -338,5 +338,23 @@ class GradleLintPluginSpec extends TestKitSpecification {
 
         then:
         !console.any { it.contains('archaic-wrapper') }
+    }
+
+    def 'autoLintGradle is always run'() {
+        createJavaSourceFile('public class Main { }')
+        buildFile << """\
+            plugins {
+                id 'java'
+                id 'nebula.lint'
+            }
+            
+            gradleLint.rules = ['dependency-parentheses']
+            """.stripIndent()
+
+        when:
+        def results = runTasksSuccessfully('compileJava')
+
+        then:
+        results.task(':autoLintGradle').outcome == TaskOutcome.SUCCESS
     }
 }

--- a/src/main/groovy/com/netflix/nebula/lint/plugin/FixGradleLintTask.groovy
+++ b/src/main/groovy/com/netflix/nebula/lint/plugin/FixGradleLintTask.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016 Netflix, Inc.
+ * Copyright 2015-2017 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.netflix.nebula.lint.plugin
 
 import com.netflix.nebula.lint.GradleLintInfoBrokerAction
@@ -47,6 +46,7 @@ class FixGradleLintTask extends DefaultTask implements VerificationTask {
     
     FixGradleLintTask() {
         outputs.upToDateWhen { false }
+        group = 'lint'
     }
     
     @TaskAction

--- a/src/main/groovy/com/netflix/nebula/lint/plugin/GradleLintReportTask.groovy
+++ b/src/main/groovy/com/netflix/nebula/lint/plugin/GradleLintReportTask.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016 Netflix, Inc.
+ * Copyright 2015-2017 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.netflix.nebula.lint.plugin
 
 import com.netflix.nebula.lint.StyledTextService
@@ -50,6 +49,7 @@ class GradleLintReportTask extends DefaultTask implements VerificationTask, Repo
     GradleLintReportTask() {
         reports = instantiator.newInstance(CodeNarcReportsImpl, this)
         outputs.upToDateWhen { false }
+        group = 'lint'
     }
 
     @TaskAction

--- a/src/main/groovy/com/netflix/nebula/lint/plugin/LintGradleTask.groovy
+++ b/src/main/groovy/com/netflix/nebula/lint/plugin/LintGradleTask.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016 Netflix, Inc.
+ * Copyright 2015-2017 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.netflix.nebula.lint.plugin
 
 import com.netflix.nebula.lint.GradleLintInfoBrokerAction
@@ -29,6 +28,10 @@ import static com.netflix.nebula.lint.StyledTextService.Styling.*
 
 class LintGradleTask extends DefaultTask {
     List<GradleLintViolationAction> listeners = []
+
+    LintGradleTask() {
+        group = 'lint'
+    }
 
     @TaskAction
     void lint() {

--- a/src/test/groovy/com/netflix/nebula/lint/plugin/FixGradleLintTaskSpec.groovy
+++ b/src/test/groovy/com/netflix/nebula/lint/plugin/FixGradleLintTaskSpec.groovy
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2016-2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.nebula.lint.plugin
 
 import com.netflix.nebula.lint.TestKitSpecification
@@ -24,7 +39,7 @@ class FixGradleLintTaskSpec extends TestKitSpecification {
         createJavaSourceFile('public class Main {}')
 
         then:
-        def results = runTasksFail('compileJava', 'fixGradleLint')
+        def results = runTasksFail('fixGradleLint')
 
         results.output.count('fixed          unused-dependency') == 1
         results.output.count('unfixed        dependency-parentheses') == 1

--- a/src/test/groovy/com/netflix/nebula/lint/plugin/LintGradleTaskSpec.groovy
+++ b/src/test/groovy/com/netflix/nebula/lint/plugin/LintGradleTaskSpec.groovy
@@ -1,8 +1,22 @@
+/*
+ * Copyright 2016-2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.nebula.lint.plugin
 
 import com.netflix.nebula.lint.TestKitSpecification
-import org.gradle.testkit.runner.UnexpectedBuildFailure
-import org.gradle.testkit.runner.UnexpectedBuildResultException
+import org.gradle.testkit.runner.TaskOutcome
 
 class LintGradleTaskSpec extends TestKitSpecification {
 
@@ -51,5 +65,23 @@ class LintGradleTaskSpec extends TestKitSpecification {
 
         then:
         runTasksFail('lintGradle')
+    }
+
+    def 'lintGradle always depends on compileJava'() {
+        given:
+        buildFile.text = """\
+            plugins {
+                id 'java'
+                id 'nebula.lint'
+            }
+            
+            gradleLint.rules = ['dependency-parentheses']
+            """.stripIndent()
+
+        when:
+        def result = runTasksSuccessfully('lintGradle')
+
+        then:
+        result.task(':compileJava').outcome == TaskOutcome.UP_TO_DATE
     }
 }

--- a/src/test/groovy/com/netflix/nebula/lint/rule/dependency/UnusedDependencyRuleSpec.groovy
+++ b/src/test/groovy/com/netflix/nebula/lint/rule/dependency/UnusedDependencyRuleSpec.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016 Netflix, Inc.
+ * Copyright 2015-2017 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.netflix.nebula.lint.rule.dependency
 
 import com.netflix.nebula.lint.TestKitSpecification
@@ -313,7 +312,7 @@ class UnusedDependencyRuleSpec extends TestKitSpecification {
     }
 
     def 'dependencies present in more than one configuration as first order dependencies can be removed from one of them'() {
-        when:
+        given:
         buildFile.text = """
             plugins {
                 id 'nebula.lint'
@@ -340,9 +339,10 @@ class UnusedDependencyRuleSpec extends TestKitSpecification {
             }
         ''')
 
-        then:
-        runTasksSuccessfully('compileTestJava', 'fixGradleLint')
+        when:
+        runTasksSuccessfully('fixGradleLint')
 
+        then:
         dependencies(buildFile, 'compile') == []
         dependencies(buildFile, 'testCompile') == ['junit:junit:4.11']
     }


### PR DESCRIPTION
…ssemble to get rules that look at dependencies. Fixes #74.