### PR TITLE
Rule spec set project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@ build/
 .gradle
 gradle.properties
 .idea/
+*.iml
+*.ipr
+*.iws

--- a/src/main/groovy/com/netflix/nebula/lint/rule/test/AbstractRuleSpec.groovy
+++ b/src/main/groovy/com/netflix/nebula/lint/rule/test/AbstractRuleSpec.groovy
@@ -64,6 +64,11 @@ abstract class AbstractRuleSpec extends ProjectSpec {
 
         return project.buildFile.text
     }
+
+    @Override
+    boolean deleteProjectDir() {
+        return false
+    }
 }
 
 class ResultsAssert {

--- a/src/main/groovy/com/netflix/nebula/lint/rule/test/AbstractRuleSpec.groovy
+++ b/src/main/groovy/com/netflix/nebula/lint/rule/test/AbstractRuleSpec.groovy
@@ -20,32 +20,40 @@ import com.netflix.nebula.lint.GradleLintFix
 import com.netflix.nebula.lint.GradleLintPatchAction
 import com.netflix.nebula.lint.plugin.NotNecessarilyGitRepository
 import com.netflix.nebula.lint.rule.GradleLintRule
+import com.netflix.nebula.lint.rule.GradleModelAware
 import nebula.test.ProjectSpec
 import org.codenarc.analyzer.StringSourceAnalyzer
 import org.codenarc.results.Results
 import org.codenarc.ruleset.CompositeRuleSet
 import org.codenarc.ruleset.RuleSet
 import org.eclipse.jgit.api.ApplyCommand
+import org.gradle.api.Project
 
 abstract class AbstractRuleSpec extends ProjectSpec {
     def setupSpec() {
         Results.mixin ResultsAssert
     }
 
-    private static RuleSet configureRuleSet(GradleLintRule... rules) {
+    private static RuleSet configureRuleSet(Project project, GradleLintRule... rules) {
         def ruleSet = new CompositeRuleSet()
-        rules.each { ruleSet.addRule(it) }
+        rules.each {
+            ruleSet.addRule(it)
+            if (it in GradleModelAware ) {
+                it.project = project
+            }
+        }
+
         ruleSet
     }
 
     Results runRulesAgainst(GradleLintRule... rules) {
-        new StringSourceAnalyzer(project.buildFile.text).analyze(configureRuleSet(rules))
+        new StringSourceAnalyzer(project.buildFile.text).analyze(configureRuleSet(this.project, rules))
     }
 
     String correct(GradleLintRule... rules) {
         def analyzer = new StringSourceAnalyzer(project.buildFile.text)
         def violations = analyzer
-                .analyze(configureRuleSet(*rules.collect { it.buildFile = project.buildFile; it }))
+                .analyze(configureRuleSet(this.project, *rules.collect { it.buildFile = project.buildFile; it }))
                 .violations
 
         def patchFile = new File(projectDir, 'lint.patch')

--- a/src/main/groovy/com/netflix/nebula/lint/rule/test/AbstractRuleSpec.groovy
+++ b/src/main/groovy/com/netflix/nebula/lint/rule/test/AbstractRuleSpec.groovy
@@ -38,11 +38,10 @@ abstract class AbstractRuleSpec extends ProjectSpec {
         def ruleSet = new CompositeRuleSet()
         rules.each {
             ruleSet.addRule(it)
-            if (it in GradleModelAware ) {
+            if (it in GradleModelAware) {
                 it.project = project
             }
         }
-
         ruleSet
     }
 


### PR DESCRIPTION
2 test-related features:

* A. sets the project for the rule before running `runRulesAgainst` and `correct` so you can use the project object in your rule (i.e. `project.file()`).
* B. does not delete the test project directory after the end of each test, similar to the `IntegrationSpec`

and 1 other change:

* add idea files to gitignore

if these make sense, i can look into writing up some tests if necessary