### PR TITLE
Improve dependency visitors

### DIFF
--- a/src/main/groovy/com/netflix/nebula/lint/rule/GradleLintRule.groovy
+++ b/src/main/groovy/com/netflix/nebula/lint/rule/GradleLintRule.groovy
@@ -474,16 +474,15 @@ abstract class GradleLintRule extends GroovyAstVisitor implements Rule {
                 }
                 def configurations
                 if (!dslStack().isEmpty() && dslStack().first() == 'subprojects') {
-                    def expressions = callStack.first().arguments.expressions
-                    if (expressions.isEmpty()) {
-                        configurations = project.childProjects.values().first().configurations
-                    } else {
-                        def expr = expressions[0]
+                    def expr = callStack.first().arguments.expressions[0]
+                    def subproject
+                    if (expr instanceof ConstantExpression || expr instanceof GStringExpression) {
                         def path = expr instanceof ConstantExpression ? expr.value : expr.text
-                        configurations = project.childProjects.values().find {
-                            it.path == path
-                        }.configurations
+                        subproject = project.childProjects.values().find { it.path == path }
+                    } else {
+                        subproject = project.childProjects.values().first()
                     }
+                    configurations = subproject.configurations
                 } else {
                     configurations = project.configurations
                 }

--- a/src/main/groovy/com/netflix/nebula/lint/rule/GradleLintRule.groovy
+++ b/src/main/groovy/com/netflix/nebula/lint/rule/GradleLintRule.groovy
@@ -59,20 +59,35 @@ abstract class GradleLintRule extends GroovyAstVisitor implements Rule {
 
     // Gradle DSL specific visitor methods
     void visitApplyPlugin(MethodCallExpression call, String plugin) {}
+
     void visitBuildScriptDependency(MethodCallExpression call, String conf, GradleDependency dep) {}
+
     void visitGradleDependency(MethodCallExpression call, String conf, GradleDependency dep) {}
+
     void visitSubprojectGradleDependency(MethodCallExpression call, String conf, GradleDependency dep) {}
+
     void visitAllprojectsGradleDependency(MethodCallExpression call, String conf, GradleDependency dep) {}
+
     void visitAnyGradleDependency(MethodCallExpression call, String conf, GradleDependency dep) {}
+
     void visitGradlePlugin(MethodCallExpression call, String conf, GradlePlugin plugin) {}
+
     void visitConfigurationExclude(MethodCallExpression call, String conf, GradleDependency exclude) {}
+
     void visitExtensionProperty(ExpressionStatement expression, String extension, String prop, String value) {}
+
     void visitExtensionProperty(ExpressionStatement expression, String extension, String prop) {}
+
     void visitDependencies(MethodCallExpression call) {}
+
     void visitPlugins(MethodCallExpression call) {}
+
     void visitTask(MethodCallExpression call, String name, Map<String, String> args) {}
+
     void visitBuildscript(MethodCallExpression call) {}
-    void visitGradleResolutionStrategyForce(MethodCallExpression call, String conf, Map<GradleDependency, Expression> forces) {}
+
+    void visitGradleResolutionStrategyForce(MethodCallExpression call, String conf, Map<GradleDependency, Expression> forces) {
+    }
 
     protected boolean isIgnored() {
         callStack.any { call ->
@@ -81,14 +96,15 @@ abstract class GradleLintRule extends GroovyAstVisitor implements Rule {
                 // for fixm-e, the first argument is the predicate that determines whether to fail the build or not
                 def ruleNameExpressions = methodName == 'ignore' ? call.arguments.expressions : call.arguments.expressions.drop(1)
 
-                List<String> rulesToIgnore = ruleNameExpressions.findAll { it instanceof ConstantExpression }.collect { it.text }
+                List<String> rulesToIgnore = ruleNameExpressions.findAll { it instanceof ConstantExpression }.collect {
+                    it.text
+                }
                 if (rulesToIgnore.isEmpty())
                     true
                 else {
                     rulesToIgnore.collect { LintRuleRegistry.findRules(it) }.flatten().contains(ruleId)
                 }
-            }
-            else false
+            } else false
         }
     }
 
@@ -103,11 +119,11 @@ abstract class GradleLintRule extends GroovyAstVisitor implements Rule {
     final List<String> dslStack(List<MethodCallExpression> calls) {
         def _dslStack
         _dslStack = { Expression expr ->
-            if(expr instanceof PropertyExpression)
+            if (expr instanceof PropertyExpression)
                 _dslStack(expr.objectExpression) + expr.propertyAsString
-            else if(expr instanceof MethodCallExpression)
+            else if (expr instanceof MethodCallExpression)
                 _dslStack(expr.objectExpression) + expr.methodAsString
-            else if(expr instanceof VariableExpression)
+            else if (expr instanceof VariableExpression)
                 expr.text == 'this' ? [] : [expr.text]
             else []
         }
@@ -134,7 +150,7 @@ abstract class GradleLintRule extends GroovyAstVisitor implements Rule {
 
     GradleViolation addBuildLintViolation(String message, ASTNode node) {
         def v = new GradleViolation(buildFile, rule, node?.lineNumber, sourceCode(node), message)
-        if(!isIgnored())
+        if (!isIgnored())
             gradleViolations.add(v)
         return v
     }
@@ -145,7 +161,7 @@ abstract class GradleLintRule extends GroovyAstVisitor implements Rule {
 
     GradleViolation addLintViolation(String message, File file, Integer lineNumber) {
         def v = new GradleViolation(file, rule, lineNumber, null, message)
-        if(!isIgnored())
+        if (!isIgnored())
             gradleViolations.add(v)
         return v
     }
@@ -169,7 +185,7 @@ abstract class GradleLintRule extends GroovyAstVisitor implements Rule {
      * prior to the starting column, and code that exists on the last line after the ending column
      */
     private final String sourceCode(ASTNode node) {
-        if(!node) return null
+        if (!node) return null
 
         // make a copy of violating lines so they can be formatted for display in a report
         def violatingLines = new ArrayList<String>(sourceCode.lines.subList(node.lineNumber - 1, node.lastLineNumber))
@@ -182,22 +198,25 @@ abstract class GradleLintRule extends GroovyAstVisitor implements Rule {
         // taken from the internal implementation of stripIndent()
         def findMinimumLeadingSpaces = { Integer count, String line ->
             int index
-            for(index = 0; index < line.length() && index < count && Character.isWhitespace(line.charAt(index)); ++index) {
+            for (index = 0; index < line.length() && index < count && Character.isWhitespace(line.charAt(index)); ++index) {
             }
             index
         }
 
         def indentFirst = violatingLines.size() > 1 ? violatingLines.drop(1).inject(Integer.MAX_VALUE, findMinimumLeadingSpaces) : 0
-        violatingLines[0] = violatingLines[0].padLeft(violatingLines[0].length()+indentFirst)
+        violatingLines[0] = violatingLines[0].padLeft(violatingLines[0].length() + indentFirst)
         violatingLines.join('\n').stripIndent()
     }
 
     /**
      * See the comment on compositeVisitor below for why we are visiting the AST separately independently of our rule definition.
      */
-    @Delegate final Rule rule = new AbstractAstVisitorRule() {
+    @Delegate
+    final Rule rule = new AbstractAstVisitorRule() {
         @Override
-        AstVisitor getAstVisitor() { new CompositeGroovyAstVisitor(visitors: [gradleAstVisitor, GradleLintRule.this], callStack: callStack) }
+        AstVisitor getAstVisitor() {
+            new CompositeGroovyAstVisitor(visitors: [gradleAstVisitor, GradleLintRule.this], callStack: callStack)
+        }
 
         private Logger logger = LoggerFactory.getLogger(GradleLintRule)
 
@@ -219,10 +238,10 @@ abstract class GradleLintRule extends GroovyAstVisitor implements Rule {
 
                 def inMethod = { name -> dslStack(callStack + call).contains(name) }
 
-                if(inMethod('dependencies')) visitMethodCallInDependencies(call)
-                if(inMethod('configurations')) visitMethodCallInConfigurations(call)
-                if(inMethod('plugins')) visitMethodCallInPlugins(call)
-                if(inMethod('resolutionStrategy')) visitMethodCallInResolutionStrategy(call)
+                if (inMethod('dependencies')) visitMethodCallInDependencies(call)
+                if (inMethod('configurations')) visitMethodCallInConfigurations(call)
+                if (inMethod('plugins')) visitMethodCallInPlugins(call)
+                if (inMethod('resolutionStrategy')) visitMethodCallInResolutionStrategy(call)
 
                 if (methodName == 'buildscript') {
                     GradleLintRule.this.visitBuildscript(call)
@@ -247,29 +266,21 @@ abstract class GradleLintRule extends GroovyAstVisitor implements Rule {
              * Supports the following definition forms:
              * task(t1)
              * task('t2')
-             * task(t3) {}
-             * task('t4') {}
-             * task t5
-             * task t6 {}
-             * task (t7,type: Wrapper)
+             * task(t3) {}* task('t4') {}* task t5
+             * task t6 {}* task (t7,type: Wrapper)
              * task ('t8',type: Wrapper)
              * task t9(type: Wrapper)
-             * task t10(type: Wrapper) {}
-             * task([:], t11)
+             * task t10(type: Wrapper) {}* task([:], t11)
              * task([type: Wrapper], t12)
-             * task([type: Wrapper], t13) {}
-             * tasks.create([name: 't14'])
-             * tasks.create([name: 't15']) {}
-             * tasks.create('t16') {}
-             * tasks.create('t17')
-             * tasks.create('t18', Wrapper) {}
-             * tasks.create('t19', Wrapper.class)
+             * task([type: Wrapper], t13) {}* tasks.create([name: 't14'])
+             * tasks.create([name: 't15']) {}* tasks.create('t16') {}* tasks.create('t17')
+             * tasks.create('t18', Wrapper) {}* tasks.create('t19', Wrapper.class)
              *
              * @author Boaz Jan
              * @param call
              * @param expressions
              */
-            private void visitPossibleTaskDefinition(MethodCallExpression call, List expressions){
+            private void visitPossibleTaskDefinition(MethodCallExpression call, List expressions) {
                 def taskName = null
                 def taskArgs = [:] as Map<String, String>
                 def possibleName = expressions.find {
@@ -305,13 +316,14 @@ abstract class GradleLintRule extends GroovyAstVisitor implements Rule {
                 def expression = statement.expression
                 if (!callStack.isEmpty()) {
                     def closureName = null
-                    switch(callStack.peek()) {
+                    switch (callStack.peek()) {
                         case MethodCallExpression: closureName = callStack.peek().methodAsString; break
                         case PropertyExpression: closureName = callStack.peek().text; break
                     }
 
                     if (expression instanceof BinaryExpression) {
-                        if (expression.rightExpression instanceof ConstantExpression) { // STYLE: nebula { moduleOwner = 'me' }
+                        if (expression.rightExpression instanceof ConstantExpression) {
+                            // STYLE: nebula { moduleOwner = 'me' }
                             // if the right side isn't a constant expression, we won't be able to evaluate it through just the AST
                             visitExtensionProperty(statement, closureName, expression.leftExpression.text,
                                     expression.rightExpression.text)
@@ -374,29 +386,31 @@ abstract class GradleLintRule extends GroovyAstVisitor implements Rule {
                                 entries.ext,
                                 entries.conf,
                                 GradleDependency.Syntax.MapNotation)
-                    } else if (call.arguments.expressions.any { it instanceof ConstantExpression || it instanceof GStringExpression }) {
+                    } else if (call.arguments.expressions.any {
+                        it instanceof ConstantExpression || it instanceof GStringExpression
+                    }) {
                         def expr = call.arguments.expressions.findResult {
-                            if(it instanceof ConstantExpression)
+                            if (it instanceof ConstantExpression)
                                 return it.value
-                            if(it instanceof GStringExpression)
+                            if (it instanceof GStringExpression)
                                 return it.text
                             return null
                         }
                         dependency = GradleDependency.fromConstant(expr)
-                    } else if(call.arguments.expressions.any { it instanceof PropertyExpression } && project != null) {
+                    } else if (call.arguments.expressions.any { it instanceof PropertyExpression } && project != null) {
                         def shell = new GroovyShell()
                         shell.setVariable('project', project as Project)
                         try {
                             Object dep = shell.evaluate('project.' + sourceCode(call.arguments))
                             dependency = GradleDependency.fromConstant(dep)
                             dependency.syntax = GradleDependency.Syntax.EvaluatedArbitraryCode
-                        } catch(Throwable t) {
+                        } catch (Throwable t) {
                             // if we cannot evaluate this expression, just give up
                             logger.debug("Unable to evaluate dependency expression ${sourceCode(call.arguments)}", t)
                         }
                     }
-                    
-                    if(dependency) {
+
+                    if (dependency) {
                         def top = dslStack().isEmpty() ? "" : dslStack().first()
                         if (top == 'allprojects') {
                             visitAllprojectsGradleDependency(call, methodName, dependency)
@@ -427,11 +441,11 @@ abstract class GradleLintRule extends GroovyAstVisitor implements Rule {
                                 return it.text
                             return null
                         }
-                        if(expr instanceof String)
+                        if (expr instanceof String)
                             plugin = new GradlePlugin(expr)
                     }
 
-                    if(plugin) {
+                    if (plugin) {
                         visitGradlePlugin(call, call.methodAsString, plugin)
                     }
                 }
@@ -439,17 +453,17 @@ abstract class GradleLintRule extends GroovyAstVisitor implements Rule {
 
             private void visitMethodCallInResolutionStrategy(MethodCallExpression call) {
                 // https://docs.gradle.org/current/dsl/org.gradle.api.artifacts.ResolutionStrategy.html
-                if(call.methodAsString == 'force') {
+                if (call.methodAsString == 'force') {
                     def forces = (call.arguments.expressions as List).findResults {
-                        if(it instanceof ConstantExpression)
+                        if (it instanceof ConstantExpression)
                             return [GradleDependency.fromConstant(it.value), it]
-                        if(it instanceof GStringExpression)
+                        if (it instanceof GStringExpression)
                             return [GradleDependency.fromConstant(it.text), it]
                         return null
                     }.flatten()
 
                     def conf = containingConfiguration(call)
-                    if(conf)
+                    if (conf)
                         visitGradleResolutionStrategyForce(call, conf, forces.toSpreadMap())
                 }
             }
@@ -460,8 +474,16 @@ abstract class GradleLintRule extends GroovyAstVisitor implements Rule {
                 }
                 def configurations
                 if (!dslStack().isEmpty() && dslStack().first() == 'subprojects') {
-                    // FIXME handle subprojects('path')
-                    configurations = project.childProjects.values().first().configurations
+                    def expressions = callStack.first().arguments.expressions
+                    if (expressions.isEmpty()) {
+                        configurations = project.childProjects.values().first().configurations
+                    } else {
+                        def expr = expressions[0]
+                        def path = expr instanceof ConstantExpression ? expr.value : expr.text
+                        configurations = project.childProjects.values().find {
+                            it.path == path
+                        }.configurations
+                    }
                 } else {
                     configurations = project.configurations
                 }
@@ -471,7 +493,7 @@ abstract class GradleLintRule extends GroovyAstVisitor implements Rule {
 
             private void visitFixme(MethodCallExpression call) {
                 def predicate = call.arguments.expressions[0]
-                switch(predicate) {
+                switch (predicate) {
                     case ConstantExpression:
                         def succesfullyComparedDate = ['yyyy-M-d', 'M/d/yy', 'M/d/yyyy'].any { pattern ->
                             try {
@@ -482,12 +504,12 @@ abstract class GradleLintRule extends GroovyAstVisitor implements Rule {
                                             'this fixme has expired -- remove it and address the underlying lint issue that caused it to be added'))
                                     true
                                 } else true
-                            } catch(ParseException ignored) {
+                            } catch (ParseException ignored) {
                                 false
                             }
                         }
 
-                        if(!succesfullyComparedDate) {
+                        if (!succesfullyComparedDate) {
                             gradleViolations.add(new GradleViolation(buildFile, new FixmeRule(), call?.lineNumber, sourceCode(call),
                                     'this fixme contains an unparseable date, use the yyyy-M-d format'))
                         }

--- a/src/main/groovy/com/netflix/nebula/lint/rule/dependency/DependencyParenthesesRule.groovy
+++ b/src/main/groovy/com/netflix/nebula/lint/rule/dependency/DependencyParenthesesRule.groovy
@@ -18,14 +18,15 @@ package com.netflix.nebula.lint.rule.dependency
 
 import com.netflix.nebula.lint.rule.GradleDependency
 import com.netflix.nebula.lint.rule.GradleLintRule
+import com.netflix.nebula.lint.rule.GradleModelAware
 import org.codehaus.groovy.ast.expr.ClosureExpression
 import org.codehaus.groovy.ast.expr.MethodCallExpression
 
-class DependencyParenthesesRule extends GradleLintRule {
+class DependencyParenthesesRule extends GradleLintRule implements GradleModelAware {
     String description = "don't put parentheses around dependency definitions unless it is necessary"
 
     @Override
-    void visitGradleDependency(MethodCallExpression call, String conf, GradleDependency dep) {
+    void visitAnyGradleDependency(MethodCallExpression call, String conf, GradleDependency dep) {
         def args = call.arguments.expressions as List
         if(!args.empty && !(args[-1] instanceof ClosureExpression)) {
             def callSource = getSourceCode().line(call.lineNumber-1)

--- a/src/main/groovy/com/netflix/nebula/lint/rule/dependency/DependencyTupleExpressionRule.groovy
+++ b/src/main/groovy/com/netflix/nebula/lint/rule/dependency/DependencyTupleExpressionRule.groovy
@@ -19,9 +19,10 @@ package com.netflix.nebula.lint.rule.dependency
 import com.netflix.nebula.lint.rule.GradleAstUtil
 import com.netflix.nebula.lint.rule.GradleDependency
 import com.netflix.nebula.lint.rule.GradleLintRule
+import com.netflix.nebula.lint.rule.GradleModelAware
 import org.codehaus.groovy.ast.expr.MethodCallExpression
 
-class DependencyTupleExpressionRule extends GradleLintRule {
+class DependencyTupleExpressionRule extends GradleLintRule implements GradleModelAware {
     String description = "use the more compact string representation of a dependency when possible"
 
     @Override

--- a/src/main/groovy/com/netflix/nebula/lint/rule/dependency/DependencyTupleExpressionRule.groovy
+++ b/src/main/groovy/com/netflix/nebula/lint/rule/dependency/DependencyTupleExpressionRule.groovy
@@ -26,7 +26,7 @@ class DependencyTupleExpressionRule extends GradleLintRule implements GradleMode
     String description = "use the more compact string representation of a dependency when possible"
 
     @Override
-    void visitGradleDependency(MethodCallExpression call, String conf, GradleDependency dep) {
+    void visitAnyGradleDependency(MethodCallExpression call, String conf, GradleDependency dep) {
         if(dep.conf == null && dep.syntax == GradleDependency.Syntax.MapNotation) {
             // FIXME what if one of the values is a function call?
             def ex = GradleAstUtil.collectEntryExpressions(call)

--- a/src/main/groovy/com/netflix/nebula/lint/rule/test/AbstractRuleSpec.groovy
+++ b/src/main/groovy/com/netflix/nebula/lint/rule/test/AbstractRuleSpec.groovy
@@ -33,6 +33,10 @@ abstract class AbstractRuleSpec extends ProjectSpec {
         Results.mixin ResultsAssert
     }
 
+    def setup() {
+        project.configurations.create('compile')
+    }
+
     private RuleSet configureRuleSet(GradleLintRule... rules) {
         def ruleSet = new CompositeRuleSet()
         rules.each {

--- a/src/test/groovy/com/netflix/nebula/lint/plugin/LintGradleTaskSpec.groovy
+++ b/src/test/groovy/com/netflix/nebula/lint/plugin/LintGradleTaskSpec.groovy
@@ -47,6 +47,7 @@ class LintGradleTaskSpec extends TestKitSpecification {
 
     def 'critical rule failures cause build failure'() {
         when:
+        debug = true
         buildFile.text = """
             plugins {
                 id 'java'

--- a/src/test/groovy/com/netflix/nebula/lint/rule/GradleLintRuleSpec.groovy
+++ b/src/test/groovy/com/netflix/nebula/lint/rule/GradleLintRuleSpec.groovy
@@ -201,6 +201,26 @@ class GradleLintRuleSpec extends AbstractRuleSpec {
         b
         b.syntax == GradleDependency.Syntax.StringNotation
     }
+
+    def 'visit dependencies in a project path subprojects block'() {
+        when:
+        def subproject = addSubproject('test')
+        subproject.configurations.create('compile')
+        project.subprojects.add(subproject)
+        project.buildFile << """
+            subprojects(':test') {
+                dependencies {
+                   compile 'b:b:1'
+                }
+            }
+        """
+
+        def b = new DependencyVisitingRule().run().subprojectDeps.find { it.name == 'b' }
+
+        then:
+        b
+        b.syntax == GradleDependency.Syntax.StringNotation
+    }
     
     def 'visit dependencies that are defined with map notation'() {
         when:

--- a/src/test/groovy/com/netflix/nebula/lint/rule/GradleLintRuleSpec.groovy
+++ b/src/test/groovy/com/netflix/nebula/lint/rule/GradleLintRuleSpec.groovy
@@ -26,6 +26,7 @@ import org.codehaus.groovy.ast.expr.VariableExpression
 import org.codehaus.groovy.ast.stmt.ExpressionStatement
 import org.gradle.api.GradleException
 import org.gradle.api.plugins.JavaPlugin
+import org.gradle.testfixtures.ProjectBuilder
 import org.joda.time.DateTime
 import org.joda.time.format.DateTimeFormat
 import org.junit.Rule
@@ -79,37 +80,6 @@ class GradleLintRuleSpec extends AbstractRuleSpec {
         then:
         pluginCount == 1
     }
-
-    def 'visit `buildScript`'() {
-        when:
-        project.buildFile << """
-            buildscript {
-                repositories {
-                    maven { url 'https://plugins.gradle.org/m2/' }
-                }
-
-                dependencies {
-                    classpath 'com.gradle:build-scan-plugin:1.1.1'
-                }
-            }
-        """
-
-        def dependenciesCount = 0
-
-        runRulesAgainst(new GradleLintRule() {
-            String description = 'test'
-
-            @Override
-            void visitGradleDependency(MethodCallExpression call, String conf, GradleDependency dep) {
-                dependenciesCount++
-            }
-        })
-
-        then:
-        dependenciesCount == 1
-    }
-
-    abstract class GradleProjectLintRule extends GradleLintRule implements GradleModelAware {}
 
     def 'visit `task`'() {
         when:
@@ -171,20 +141,53 @@ class GradleLintRuleSpec extends AbstractRuleSpec {
         calls.size() == taskCount
     }
 
-    private class DependencyVisitingRule extends GradleLintRule {
-        final String description = 'visit dependencies'
-        List<GradleDependency> deps = []
-        
-        @Override
-        void visitGradleDependency(MethodCallExpression call, String conf, GradleDependency dep) {
-            deps += dep
-        }
-        
-        DependencyVisitingRule run() { runRulesAgainst(this); this }
+    def 'visit dependencies in buildscript'() {
+        when:
+        project.buildFile << """
+            buildscript {
+                repositories {
+                    maven { url 'https://plugins.gradle.org/m2/' }
+                }
+
+                dependencies {
+                    classpath 'com.gradle:build-scan-plugin:1.1.1'
+                }
+            }
+        """
+
+        def dep = new DependencyVisitingRule().run().buildscriptDeps.first()
+
+        then:
+        dep.name == 'build-scan-plugin'
     }
-    
+
+    def 'visit dependencies in allprojects block'() {
+        when:
+        project.configurations.create('compile')
+        project.buildFile << """
+            allprojects {
+                apply plugin: 'java'
+            
+                dependencies {
+                   compile 'b:b:1'
+                }
+            }
+        """
+
+        def b = new DependencyVisitingRule().run().allprojectDeps.find { it.name == 'b' }
+
+        then:
+        b
+        b.syntax == GradleDependency.Syntax.StringNotation
+    }
+
+
+
     def 'visit dependencies in subprojects block'() {
         when:
+        def subproject = addSubproject('test')
+        subproject.configurations.create('compile')
+        project.subprojects.add(subproject)
         project.buildFile << """
             subprojects {
                 dependencies {
@@ -193,7 +196,7 @@ class GradleLintRuleSpec extends AbstractRuleSpec {
             }
         """
 
-        def b = new DependencyVisitingRule().run().deps.find { it.name == 'b' }
+        def b = new DependencyVisitingRule().run().subprojectDeps.find { it.name == 'b' }
 
         then:
         b
@@ -202,6 +205,7 @@ class GradleLintRuleSpec extends AbstractRuleSpec {
     
     def 'visit dependencies that are defined with map notation'() {
         when:
+        project.configurations.create('compile')
         project.buildFile << """
             dependencies {
                compile group: 'a', name: 'a', version: '1'
@@ -219,6 +223,7 @@ class GradleLintRuleSpec extends AbstractRuleSpec {
 
     def 'visit dependency with no version'() {
         when:
+        project.configurations.create('compile')
         project.buildFile << """
             dependencies {
                compile 'a:a'
@@ -268,7 +273,7 @@ class GradleLintRuleSpec extends AbstractRuleSpec {
             }
 
             @Override
-            void visitGradleDependency(MethodCallExpression call, String conf, GradleDependency dep) {
+            void visitDependencies(MethodCallExpression call) {
                 if (bookmark('lastApplyPlugin')) {
                     addBuildLintViolation('should generate source jar', call)
                             .insertAfter(bookmark('lastApplyPlugin'), "apply plugin: 'nebula.source-jar'")
@@ -289,6 +294,7 @@ class GradleLintRuleSpec extends AbstractRuleSpec {
             }
         """.stripIndent()
     }
+
 
     @Unroll
     def 'violations suppression inside of ignore blocks when ignored rule(s) is `#rules`'() {
@@ -574,5 +580,37 @@ class GradleLintRuleSpec extends AbstractRuleSpec {
         LintRuleRegistry.classLoader = new URLClassLoader([temp.root.toURI().toURL()] as URL[], getClass().getClassLoader())
 
         noPluginsRule
+    }
+
+    abstract class GradleProjectLintRule extends GradleLintRule implements GradleModelAware {}
+
+    private class DependencyVisitingRule extends GradleLintRule implements GradleModelAware {
+        final String description = 'visit dependencies'
+        List<GradleDependency> deps = []
+        List<GradleDependency> allprojectDeps = []
+        List<GradleDependency> subprojectDeps = []
+        List<GradleDependency> buildscriptDeps = []
+
+        @Override
+        void visitGradleDependency(MethodCallExpression call, String conf, GradleDependency dep) {
+            deps += dep
+        }
+
+        @Override
+        void visitBuildScriptDependency(MethodCallExpression call, String conf, GradleDependency dep) {
+            buildscriptDeps += dep
+        }
+
+        @Override
+        void visitSubprojectGradleDependency(MethodCallExpression call, String conf, GradleDependency dep) {
+            subprojectDeps += dep
+        }
+
+        @Override
+        void visitAllprojectsGradleDependency(MethodCallExpression call, String conf, GradleDependency dep) {
+            allprojectDeps += dep
+        }
+
+        DependencyVisitingRule run() { runRulesAgainst(this); this }
     }
 }

--- a/src/test/groovy/com/netflix/nebula/lint/rule/GradleLintRuleSpec.groovy
+++ b/src/test/groovy/com/netflix/nebula/lint/rule/GradleLintRuleSpec.groovy
@@ -163,7 +163,6 @@ class GradleLintRuleSpec extends AbstractRuleSpec {
 
     def 'visit dependencies in allprojects block'() {
         when:
-        project.configurations.create('compile')
         project.buildFile << """
             allprojects {
                 apply plugin: 'java'
@@ -205,7 +204,6 @@ class GradleLintRuleSpec extends AbstractRuleSpec {
     
     def 'visit dependencies that are defined with map notation'() {
         when:
-        project.configurations.create('compile')
         project.buildFile << """
             dependencies {
                compile group: 'a', name: 'a', version: '1'
@@ -223,7 +221,6 @@ class GradleLintRuleSpec extends AbstractRuleSpec {
 
     def 'visit dependency with no version'() {
         when:
-        project.configurations.create('compile')
         project.buildFile << """
             dependencies {
                compile 'a:a'


### PR DESCRIPTION
It's bogus to visit buildscript/allprojects and subproject dependencies without that context, as rules just assume they're running in the context of the project.

This also removes the default configuration fallbacks, so in order to visit dependencies, a rule must be GradleModelAware.