### PR TITLE
Create a task to run just critical lint rules

### DIFF
--- a/src/main/groovy/com/netflix/nebula/lint/plugin/FixGradleLintTask.groovy
+++ b/src/main/groovy/com/netflix/nebula/lint/plugin/FixGradleLintTask.groovy
@@ -51,7 +51,7 @@ class FixGradleLintTask extends DefaultTask implements VerificationTask {
     
     @TaskAction
     void lintCorrections() {
-        def violations = new LintService().lint(project).violations
+        def violations = new LintService().lint(project, false).violations
                 .unique { v1, v2 -> v1.is(v2) ? 0 : 1 }
 
         (userDefinedListeners + infoBrokerAction + new GradleLintPatchAction(project)).each {

--- a/src/main/groovy/com/netflix/nebula/lint/plugin/GradleLintExtension.groovy
+++ b/src/main/groovy/com/netflix/nebula/lint/plugin/GradleLintExtension.groovy
@@ -17,7 +17,6 @@
 package com.netflix.nebula.lint.plugin
 
 import com.netflix.nebula.lint.GradleLintViolationAction
-import com.netflix.nebula.lint.GradleViolation
 import org.gradle.api.Incubating
 import org.gradle.api.InvalidUserDataException
 
@@ -37,6 +36,8 @@ class GradleLintExtension {
     String reportFormat = 'html'
     boolean alwaysRun = true
     boolean autoLintAfterFailure = true
+
+    List<String> skipForTasks = ['help', 'tasks', 'dependencies', 'dependencyInsight', 'components', 'model', 'projects', 'properties', 'wrapper']
 
     @Incubating
     List<GradleLintViolationAction> listeners = []
@@ -63,4 +64,8 @@ class GradleLintExtension {
     void fixme(String ignoreUntil, String r1, String r2, String r3, Closure c) { c() }
     void fixme(String ignoreUntil, String r1, String r2, String r3, String r4, Closure c) { c() }
     void fixme(String ignoreUntil, String r1, String r2, String r3, String r4, String r5, Closure c) { c() }
+
+    void skipForTask(String taskName) {
+        skipForTasks.add(taskName)
+    }
 }

--- a/src/main/groovy/com/netflix/nebula/lint/plugin/GradleLintPlugin.groovy
+++ b/src/main/groovy/com/netflix/nebula/lint/plugin/GradleLintPlugin.groovy
@@ -50,7 +50,7 @@ class GradleLintPlugin implements Plugin<Project> {
             def fixTask2 = project.tasks.create('fixLintGradle', FixGradleLintTask)
             fixTask2.userDefinedListeners = lintExt.listeners
 
-            project.gradle.addBuildListener(new LintListener() {
+            project.gradle.addListener(new LintListener() {
                 def allTasks
 
                 @Override

--- a/src/main/groovy/com/netflix/nebula/lint/plugin/GradleLintPlugin.groovy
+++ b/src/main/groovy/com/netflix/nebula/lint/plugin/GradleLintPlugin.groovy
@@ -15,6 +15,7 @@
  */
 package com.netflix.nebula.lint.plugin
 
+import com.netflix.nebula.lint.plugin.GradleLintPlugin.LintListener
 import org.gradle.BuildAdapter
 import org.gradle.BuildResult
 import org.gradle.api.Plugin
@@ -67,13 +68,14 @@ class GradleLintPlugin implements Plugin<Project> {
                 private boolean onlyIf() {
                     def shouldLint = project.hasProperty('gradleLint.alwaysRun') ?
                             Boolean.valueOf(project.property('gradleLint.alwaysRun').toString()) : lintExt.alwaysRun
+                    def skipForSpecificTask = project.gradle.startParameter.taskNames.any { lintExt.skipForTasks.contains(it) }
                     def hasFailedTask = !lintExt.autoLintAfterFailure && allTasks.any { it.state.failure != null }
                     //when we already have failed critical lint task we don't want to run autolint
                     def hasFailedCriticalLintTask = allTasks.any { it == criticalLintTask && it.state.failure != null }
                     def hasExplicitLintTask = allTasks.any {
                         it == fixTask || it == fixTask2 || it == manualLintTask || it == autoLintTask
                     }
-                    shouldLint && !hasFailedTask && !hasExplicitLintTask && !hasFailedCriticalLintTask
+                    shouldLint && !skipForSpecificTask && !hasFailedTask && !hasExplicitLintTask && !hasFailedCriticalLintTask
                 }
             })
         }

--- a/src/main/groovy/com/netflix/nebula/lint/plugin/GradleLintReportTask.groovy
+++ b/src/main/groovy/com/netflix/nebula/lint/plugin/GradleLintReportTask.groovy
@@ -56,7 +56,7 @@ class GradleLintReportTask extends DefaultTask implements VerificationTask, Repo
     void generateReport() {
         if (reports.enabled) {
             def lintService = new LintService()
-            def results = lintService.lint(project)
+            def results = lintService.lint(project, false)
             def violationCount = results.violations.size()
             def textOutput = new StyledTextService(getServices())
 

--- a/src/main/groovy/com/netflix/nebula/lint/plugin/LintGradleTask.groovy
+++ b/src/main/groovy/com/netflix/nebula/lint/plugin/LintGradleTask.groovy
@@ -26,6 +26,7 @@ class LintGradleTask extends DefaultTask {
     List<GradleLintViolationAction> listeners = []
 
     boolean failOnWarning = false
+    boolean onlyCriticalRules = false
 
     LintGradleTask() {
         group = 'lint'
@@ -33,7 +34,7 @@ class LintGradleTask extends DefaultTask {
 
     @TaskAction
     void lint() {
-        def violations = new LintService().lint(project).violations
+        def violations = new LintService().lint(project, onlyCriticalRules).violations
                 .unique { v1, v2 -> v1.is(v2) ? 0 : 1 }
 
         (listeners + new GradleLintPatchAction(project) + new GradleLintInfoBrokerAction(project) + consoleOutputAction).each {

--- a/src/test/groovy/com/netflix/nebula/lint/plugin/GradleLintPluginSpec.groovy
+++ b/src/test/groovy/com/netflix/nebula/lint/plugin/GradleLintPluginSpec.groovy
@@ -163,7 +163,6 @@ class GradleLintPluginSpec extends TestKitSpecification {
         def console = results.output.readLines()
 
         then:
-        println(results.output)
         console.findAll { it.startsWith('error') }.size() == 1
         console.any { it.contains('dependency-tuple') }
         console.every { ! it.contains('dependency-parentheses') }
@@ -335,7 +334,6 @@ class GradleLintPluginSpec extends TestKitSpecification {
 
         then:
         def results = runTasksSuccessfully('generateGradleLintReport')
-        println results.output
 
         when:
         def console = results.output.readLines()

--- a/src/test/groovy/com/netflix/nebula/lint/plugin/GradleLintPluginSpec.groovy
+++ b/src/test/groovy/com/netflix/nebula/lint/plugin/GradleLintPluginSpec.groovy
@@ -456,6 +456,39 @@ class GradleLintPluginSpec extends TestKitSpecification {
         !console.any { it.contains('archaic-wrapper') }
     }
 
+    @Unroll
+    def 'lint task does not run for task #taskName'() {
+        when:
+        buildFile << """
+            plugins {
+                id 'nebula.lint'
+                id 'java'
+            }
+
+            gradleLint {
+                rules = ['archaic-wrapper']
+            }
+
+            task wrapper(type: Wrapper){
+                gradleVersion = '0.1'
+            }
+        """
+
+        then:
+        // build would normally trigger lintGradle, but will not when alwaysRun = false
+        def results = runTasksSuccessfully(taskName)
+
+        when:
+        def console = results.output.readLines()
+
+        then:
+        !console.any { it.contains('archaic-wrapper') }
+
+        where:
+        taskName << ['help', 'tasks', 'dependencies', 'components',
+                     'model', 'projects', 'properties', 'wrapper']
+    }
+
     def 'autoLintGradle is always run'() {
         createJavaSourceFile('public class Main { }')
         buildFile << """\

--- a/src/test/groovy/com/netflix/nebula/lint/plugin/LintGradleTaskSpec.groovy
+++ b/src/test/groovy/com/netflix/nebula/lint/plugin/LintGradleTaskSpec.groovy
@@ -131,7 +131,7 @@ class LintGradleTaskSpec extends TestKitSpecification {
         def result = runTasksFail('compileJava')
 
         then:
-        result.task(':autoLintGradle').outcome == TaskOutcome.SUCCESS
+        result.output.contains('This project contains lint violations.')
     }
 
 
@@ -161,7 +161,7 @@ class LintGradleTaskSpec extends TestKitSpecification {
         def result = runTasksFail('compileJava')
 
         then:
-        result.task(':autoLintGradle').outcome == TaskOutcome.SKIPPED
+        ! result.output.contains('This project contains lint violations.')
     }
 
     def 'lint finds all violations in all applied files with bookmark rule'() {


### PR DESCRIPTION
My idea how to add a task to run just critical rules. The autoLintGradle is now executed through BuildListener. I added an option to skip the lint through CLI because `-x autoLintGradle` won't work anymore. I would hook `criticalLintGradle` to publishing verification in our internal plugins.