### PR TITLE
Undeclared dependency

### DIFF
--- a/src/main/groovy/com/netflix/nebula/lint/rule/dependency/DependencyHelper.groovy
+++ b/src/main/groovy/com/netflix/nebula/lint/rule/dependency/DependencyHelper.groovy
@@ -2,7 +2,13 @@ package com.netflix.nebula.lint.rule.dependency
 
 import com.netflix.nebula.lint.GradleViolation
 import com.netflix.nebula.lint.rule.GradleDependency
-import org.codehaus.groovy.ast.expr.*
+import org.codehaus.groovy.ast.expr.BinaryExpression
+import org.codehaus.groovy.ast.expr.ClosureExpression
+import org.codehaus.groovy.ast.expr.ConstantExpression
+import org.codehaus.groovy.ast.expr.GStringExpression
+import org.codehaus.groovy.ast.expr.MapExpression
+import org.codehaus.groovy.ast.expr.MethodCallExpression
+import org.codehaus.groovy.ast.expr.NamedArgumentListExpression
 
 class DependencyHelper {
     static void removeVersion(GradleViolation violation, MethodCallExpression call, GradleDependency dep) {

--- a/src/main/groovy/com/netflix/nebula/lint/rule/dependency/DependencyHelper.groovy
+++ b/src/main/groovy/com/netflix/nebula/lint/rule/dependency/DependencyHelper.groovy
@@ -2,13 +2,7 @@ package com.netflix.nebula.lint.rule.dependency
 
 import com.netflix.nebula.lint.GradleViolation
 import com.netflix.nebula.lint.rule.GradleDependency
-import org.codehaus.groovy.ast.expr.BinaryExpression
-import org.codehaus.groovy.ast.expr.ClosureExpression
-import org.codehaus.groovy.ast.expr.ConstantExpression
-import org.codehaus.groovy.ast.expr.GStringExpression
-import org.codehaus.groovy.ast.expr.MapExpression
-import org.codehaus.groovy.ast.expr.MethodCallExpression
-import org.codehaus.groovy.ast.expr.NamedArgumentListExpression
+import org.codehaus.groovy.ast.expr.*
 
 class DependencyHelper {
     static void removeVersion(GradleViolation violation, MethodCallExpression call, GradleDependency dep) {

--- a/src/main/groovy/com/netflix/nebula/lint/rule/dependency/DependencyService.groovy
+++ b/src/main/groovy/com/netflix/nebula/lint/rule/dependency/DependencyService.groovy
@@ -441,4 +441,22 @@ class DependencyService {
         def androidReleaseOutput = project.tasks.findByName('compileReleaseJavaWithJavac')?.destinationDir
         return androidReleaseOutput
     }
+
+    Comparator<? super SourceSet> sourceSetComparator() {
+        // sort the sourceSets from least dependent to most dependent, e.g. [main, test, integTest]
+        new Comparator<SourceSet>() {
+            @Override
+            int compare(SourceSet s1, SourceSet s2) {
+                def c1 = project.configurations.findByName(s1.compileConfigurationName)
+                def c2 = project.configurations.findByName(s2.compileConfigurationName)
+
+                if (allExtendsFrom(c1).contains(c2))
+                    1
+                if (allExtendsFrom(c2).contains(c1))
+                    -1
+                // secondary sorting if there is no relationship between these source sets
+                else c1.name <=> c2.name
+            }
+        }
+    }
 }

--- a/src/main/groovy/com/netflix/nebula/lint/rule/dependency/UndeclaredDependencyRule.groovy
+++ b/src/main/groovy/com/netflix/nebula/lint/rule/dependency/UndeclaredDependencyRule.groovy
@@ -1,7 +1,6 @@
 package com.netflix.nebula.lint.rule.dependency
 
 import com.google.common.collect.ImmutableMap
-import com.netflix.nebula.lint.rule.GradleDependency
 import com.netflix.nebula.lint.rule.GradleLintRule
 import com.netflix.nebula.lint.rule.GradleModelAware
 import org.codehaus.groovy.ast.ASTNode
@@ -45,16 +44,6 @@ class UndeclaredDependencyRule extends GradleLintRule implements GradleModelAwar
     @Override
     void visitSubprojects(MethodCallExpression call) {
         bookmark(SUBPROJECTS_BLOCK, call)
-    }
-
-    @Override
-    void visitAllprojectsGradleDependency(MethodCallExpression call, String conf, GradleDependency dep) {
-        bookmark(ALLPROJECTS_DEPENDENCIES_BLOCK, call)
-    }
-
-    @Override
-    void visitSubprojectGradleDependency(MethodCallExpression call, String conf, GradleDependency dep) {
-        bookmark(SUBPROJECTS_DEPENDENCIES_BLOCK, call)
     }
 
     @Override

--- a/src/main/groovy/com/netflix/nebula/lint/rule/dependency/UndeclaredDependencyRule.groovy
+++ b/src/main/groovy/com/netflix/nebula/lint/rule/dependency/UndeclaredDependencyRule.groovy
@@ -1,0 +1,145 @@
+package com.netflix.nebula.lint.rule.dependency
+
+import com.google.common.collect.ImmutableMap
+import com.netflix.nebula.lint.rule.GradleDependency
+import com.netflix.nebula.lint.rule.GradleLintRule
+import com.netflix.nebula.lint.rule.GradleModelAware
+import org.codehaus.groovy.ast.ASTNode
+import org.codehaus.groovy.ast.ClassNode
+import org.codehaus.groovy.ast.expr.Expression
+import org.codehaus.groovy.ast.expr.MethodCallExpression
+import org.gradle.api.artifacts.ModuleVersionIdentifier
+import org.gradle.api.plugins.JavaPluginConvention
+
+class UndeclaredDependencyRule extends GradleLintRule implements GradleModelAware {
+    private static final String SUBPROJECTS_BLOCK = 'subprojectsBlock'
+    private static final String ALLPROJECTS_BLOCK = 'allprojectsBlock'
+    private static final String ROOT_BLOCK = 'rootBlock'
+    private static final String SUBPROJECTS_DEPENDENCIES_BLOCK = 'subprojectsDependenciesBlock'
+    private static final String ALLPROJECTS_DEPENDENCIES_BLOCK = 'allprojectsDependenciesBlock'
+    private static final String ROOT_DEPENDENCIES_BLOCK = 'rootDependenciesBlock'
+    private static final List<String> BLOCKS_TO_SEARCH_IN = [
+            ALLPROJECTS_BLOCK,
+            SUBPROJECTS_BLOCK,
+            ROOT_BLOCK
+    ]
+    private static final Map<String, String> DEPENDENCY_BLOCK_ASSOCIATIONS = ImmutableMap.builder()
+            .put(ALLPROJECTS_BLOCK, ALLPROJECTS_DEPENDENCIES_BLOCK)
+            .put(SUBPROJECTS_BLOCK, SUBPROJECTS_DEPENDENCIES_BLOCK)
+            .put(ROOT_BLOCK, ROOT_DEPENDENCIES_BLOCK)
+            .build()
+
+    String description = 'Ensure that directly used transitives are declared as first order dependencies, for Gradle versions 4.5 - 5'
+    DependencyService dependencyService
+
+    @Override
+    protected void beforeApplyTo() {
+        dependencyService = DependencyService.forProject(project)
+    }
+
+    @Override
+    void visitAllprojects(MethodCallExpression call) {
+        bookmark(ALLPROJECTS_BLOCK, call)
+    }
+
+    @Override
+    void visitSubprojects(MethodCallExpression call) {
+        bookmark(SUBPROJECTS_BLOCK, call)
+    }
+
+    @Override
+    void visitAllprojectsGradleDependency(MethodCallExpression call, String conf, GradleDependency dep) {
+        bookmark(ALLPROJECTS_DEPENDENCIES_BLOCK, call)
+    }
+
+    @Override
+    void visitSubprojectGradleDependency(MethodCallExpression call, String conf, GradleDependency dep) {
+        bookmark(SUBPROJECTS_DEPENDENCIES_BLOCK, call)
+    }
+
+    @Override
+    void visitClass(ClassNode classNode) {
+        bookmark(ROOT_BLOCK, classNode)
+    }
+
+    @Override
+    void visitDependencies(MethodCallExpression call) {
+        def parentNode = parentNode()
+        if (parentIs(parentNode, 'allprojects')) {
+            bookmark(ALLPROJECTS_DEPENDENCIES_BLOCK, call)
+        } else if (parentIs(parentNode, 'subprojects')) {
+            bookmark(SUBPROJECTS_DEPENDENCIES_BLOCK, call)
+        } else if (parentNode == null) {
+            bookmark(ROOT_DEPENDENCIES_BLOCK, call)
+        }
+    }
+
+    @Override
+    protected void visitClassComplete(ClassNode node) {
+        Set<ModuleVersionIdentifier> insertedDependencies = [] as Set
+        Map<String, HashMap<String, ASTNode>> violations = new HashMap()
+
+        BLOCKS_TO_SEARCH_IN.each { currentBlock ->
+            if (bookmark(currentBlock) != null) {
+                def convention = project.convention.findPlugin(JavaPluginConvention)
+                if (convention != null) {
+                    // sort the sourceSets from least dependent to most dependent, e.g. [main, test, integTest]
+                    def sortedSourceSets = convention.sourceSets.sort(false, dependencyService.sourceSetComparator())
+
+                    sortedSourceSets.each { sourceSet ->
+                        def confName = sourceSet.compileConfigurationName
+                        violations.put(confName, new HashMap())
+
+                        dependencyService.undeclaredDependencies(confName).each { undeclared ->
+                            // only add the dependency in the lowest configuration that requires it
+                            if (insertedDependencies.add(undeclared)) {
+                                def dependencyBlock = bookmark(DEPENDENCY_BLOCK_ASSOCIATIONS.get(currentBlock))
+                                if (dependencyBlock != null) {
+
+                                    // collect violations for handling later
+                                    HashMap<String, ASTNode> violationsForConfig = violations.get(confName)
+                                    violationsForConfig.put(undeclared.toString(), dependencyBlock)
+
+                                    violations.put(confName, violationsForConfig)
+                                } else if (parentNode() == null) {
+                                    // there is no dependencies block, and this is not in an allprojects or subprojects block
+                                    addBuildLintViolation("one or more classes in $undeclared are required by your code directly, " +
+                                            "and you require a dependencies block in your subproject $project")
+                                            .insertAfter(project.buildFile, 0, """\
+                                        dependencies {
+                                        }
+                                        """.stripIndent())
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        addUndeclaredDependenciesAlphabetically(violations)
+    }
+
+    private void addUndeclaredDependenciesAlphabetically(Map<String, Map> violations) {
+        TreeMap<String, Map> sortedViolations = new TreeMap<String, Map>()
+        sortedViolations.putAll(violations)
+
+        for (Map.Entry<String, Map<String, ASTNode>> entry : sortedViolations.entrySet()) {
+            String configurationName = entry.getKey()
+            TreeMap sortedDependenciesAndBlocks = new TreeMap<String, ASTNode>()
+            sortedDependenciesAndBlocks.putAll(entry.getValue())
+
+            for (Map.Entry<String, ASTNode> dependencyAndBlock : sortedDependenciesAndBlocks.entrySet()) {
+                String undeclaredDependency = dependencyAndBlock.getKey()
+                ASTNode dependencyBlock = dependencyAndBlock.getValue()
+
+                addBuildLintViolation("one or more classes in $undeclaredDependency are required by your code directly")
+                        .insertIntoClosureAtTheEnd(dependencyBlock, "$configurationName '$undeclaredDependency'")
+            }
+        }
+    }
+
+    private static Boolean parentIs(Expression parentNode, String parentAsString) {
+        parentNode instanceof MethodCallExpression && ((MethodCallExpression) parentNode).methodAsString == parentAsString
+    }
+}

--- a/src/main/groovy/com/netflix/nebula/lint/rule/dependency/UnusedDependencyRule.groovy
+++ b/src/main/groovy/com/netflix/nebula/lint/rule/dependency/UnusedDependencyRule.groovy
@@ -8,7 +8,6 @@ import org.codehaus.groovy.ast.expr.MethodCallExpression
 import org.gradle.api.artifacts.ModuleIdentifier
 import org.gradle.api.artifacts.ModuleVersionIdentifier
 import org.gradle.api.plugins.JavaPluginConvention
-import org.gradle.api.tasks.SourceSet
 
 class UnusedDependencyRule extends GradleLintRule implements GradleModelAware {
     String description = 'remove unused dependencies, relocate dependencies to the correct configuration, and ensure that directly used transitives are declared as first order dependencies'
@@ -94,20 +93,7 @@ class UnusedDependencyRule extends GradleLintRule implements GradleModelAware {
         def convention = project.convention.findPlugin(JavaPluginConvention)
         if(convention) {
             // sort the sourceSets from least dependent to most dependent, e.g. [main, test, integTest]
-            def sortedSourceSets = convention.sourceSets.sort(false, new Comparator<SourceSet>() {
-                @Override
-                int compare(SourceSet s1, SourceSet s2) {
-                    def c1 = project.configurations.findByName(s1.compileConfigurationName)
-                    def c2 = project.configurations.findByName(s2.compileConfigurationName)
-
-                    if(dependencyService.allExtendsFrom(c1).contains(c2))
-                        1
-                    if(dependencyService.allExtendsFrom(c2).contains(c1))
-                        -1
-                    // secondary sorting if there is no relationship between these source sets
-                    else c1.name <=> c2.name
-                }
-            })
+            def sortedSourceSets = convention.sourceSets.sort(false, dependencyService.sourceSetComparator())
 
             sortedSourceSets.each { sourceSet ->
                 def confName = sourceSet.compileConfigurationName

--- a/src/main/resources/META-INF/lint-rules/undeclared-dependency.properties
+++ b/src/main/resources/META-INF/lint-rules/undeclared-dependency.properties
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-includes=unused-exclude-by-conf,unused-exclude-by-dep,unused-dependency,duplicate-dependency-class,transitive-duplicate-dependency-class,overridden-dependency-version,recommended-versions,undeclared-dependency
+implementation-class=com.netflix.nebula.lint.rule.dependency.UndeclaredDependencyRule

--- a/src/test/groovy/com/netflix/nebula/lint/plugin/FixGradleLintTaskSpec.groovy
+++ b/src/test/groovy/com/netflix/nebula/lint/plugin/FixGradleLintTaskSpec.groovy
@@ -175,9 +175,10 @@ dependencies {\r
 
             gradleLint.rules = ['all-dependencies']
             """.stripIndent()
+        gradleVersion = '2.13'
 
         when:
-        def results = runTasksSuccessfullyWithGradleVersion('2.13', 'assemble', 'lintGradle')
+        def results = runTasksSuccessfully('assemble', 'lintGradle')
 
         then:
         println results?.output

--- a/src/test/groovy/com/netflix/nebula/lint/rule/GradleLintRuleSpec.groovy
+++ b/src/test/groovy/com/netflix/nebula/lint/rule/GradleLintRuleSpec.groovy
@@ -24,9 +24,7 @@ import org.codehaus.groovy.ast.expr.Expression
 import org.codehaus.groovy.ast.expr.MethodCallExpression
 import org.codehaus.groovy.ast.expr.VariableExpression
 import org.codehaus.groovy.ast.stmt.ExpressionStatement
-import org.gradle.api.GradleException
 import org.gradle.api.plugins.JavaPlugin
-import org.gradle.testfixtures.ProjectBuilder
 import org.joda.time.DateTime
 import org.joda.time.format.DateTimeFormat
 import org.junit.Rule
@@ -58,11 +56,12 @@ class GradleLintRuleSpec extends AbstractRuleSpec {
         pluginCount == 1
     }
 
-    def 'visit `plugins`'() {
+    @Unroll
+    def 'visit `plugins` - #plugin'() {
         when:
         project.buildFile << """
             plugins {
-             id 'java'
+             id '${plugin}'
             }
         """
 
@@ -79,6 +78,9 @@ class GradleLintRuleSpec extends AbstractRuleSpec {
 
         then:
         pluginCount == 1
+
+        where:
+        plugin << ['java', 'org.gradle.java']
     }
 
     def 'visit `task`'() {

--- a/src/test/groovy/com/netflix/nebula/lint/rule/dependency/ArtifactHelpers.groovy
+++ b/src/test/groovy/com/netflix/nebula/lint/rule/dependency/ArtifactHelpers.groovy
@@ -18,6 +18,7 @@
 
 package com.netflix.nebula.lint.rule.dependency
 
+import groovy.transform.PackageScope
 import nebula.test.dependencies.Coordinate
 
 import java.util.jar.Attributes
@@ -25,6 +26,7 @@ import java.util.jar.JarOutputStream
 import java.util.jar.Manifest
 import java.util.zip.ZipEntry
 
+@PackageScope
 class ArtifactHelpers {
     protected static File setupSamplePomWith(File repo, Coordinate coordinate, String sampleFileContents) {
         def sample = new File(repo, coordinate.getGroup() + File.separator + coordinate.getArtifact() + File.separator + coordinate.getVersion())

--- a/src/test/groovy/com/netflix/nebula/lint/rule/dependency/ArtifactHelpers.groovy
+++ b/src/test/groovy/com/netflix/nebula/lint/rule/dependency/ArtifactHelpers.groovy
@@ -1,0 +1,69 @@
+/**
+ *
+ *  Copyright 2018 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+
+package com.netflix.nebula.lint.rule.dependency
+
+import nebula.test.dependencies.Coordinate
+
+import java.util.jar.Attributes
+import java.util.jar.JarOutputStream
+import java.util.jar.Manifest
+import java.util.zip.ZipEntry
+
+class ArtifactHelpers {
+    protected static File setupSamplePomWith(File repo, Coordinate coordinate, String sampleFileContents) {
+        def sample = new File(repo, coordinate.getGroup() + File.separator + coordinate.getArtifact() + File.separator + coordinate.getVersion())
+        sample.mkdirs()
+        def sampleFile = new File(sample, coordinate.getArtifact() + '-' + coordinate.getVersion() + '.pom')
+        sampleFile << sampleFileContents
+    }
+
+    protected static setupSampleJar(File repo, Coordinate coordinate) {
+        def sampleJarClasspath = repo.absolutePath + File.separator +
+                coordinate.getGroup() + File.separator +
+                coordinate.getArtifact() + File.separator +
+                coordinate.getVersion() + File.separator +
+                coordinate.getArtifact() + '-' + coordinate.getVersion() + '.jar'
+        def jar = new File(sampleJarClasspath)
+        jar.createNewFile()
+        createJar(jar, manifestWithClasspath(sampleJarClasspath))
+    }
+
+    private static def createJar(File jarFile, Manifest manifest = null) throws IOException {
+        def jarOutputStream
+
+        if (manifest == null) {
+            jarOutputStream = new JarOutputStream(new FileOutputStream(jarFile))
+        } else {
+            jarOutputStream = new JarOutputStream(new FileOutputStream(jarFile), manifest)
+        }
+
+        jarOutputStream.putNextEntry(new ZipEntry("META-INF/"))
+        jarOutputStream.close()
+    }
+
+    private static Manifest manifestWithClasspath(def manifestClasspath) {
+        Manifest manifest = new Manifest()
+        Attributes attributes = manifest.getMainAttributes()
+        attributes.put(Attributes.Name.MANIFEST_VERSION, "1.0")
+        if (manifestClasspath != null) {
+            attributes.putValue("Class-Path", manifestClasspath)
+        }
+        return manifest
+    }
+}

--- a/src/test/groovy/com/netflix/nebula/lint/rule/dependency/RecommendedVersionsRuleSpec.groovy
+++ b/src/test/groovy/com/netflix/nebula/lint/rule/dependency/RecommendedVersionsRuleSpec.groovy
@@ -934,6 +934,9 @@ class RecommendedVersionsRuleSpec extends IntegrationSpec {
     }
 
     private void setupGradleVersion(String versionOfGradle) {
+        if (versionOfGradle == null) {
+            throw new RuntimeException('test setup issue: version of gradle to set cannot be null')
+        }
         gradleVersion = versionOfGradle
     }
 

--- a/src/test/groovy/com/netflix/nebula/lint/rule/dependency/UndeclaredDependencyRuleSpec.groovy
+++ b/src/test/groovy/com/netflix/nebula/lint/rule/dependency/UndeclaredDependencyRuleSpec.groovy
@@ -1,0 +1,603 @@
+/*
+ * Copyright 2015-2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.nebula.lint.rule.dependency
+
+import com.netflix.nebula.lint.TestKitSpecification
+import nebula.test.dependencies.Coordinate
+import nebula.test.dependencies.maven.Pom
+
+class UndeclaredDependencyRuleSpec extends TestKitSpecification {
+    private static final def sample = new Coordinate('sample', 'alpha', '1.0')
+    private static final def commonsLogging = new Coordinate('commons-logging', 'commons-logging', '1.2')
+    private static final def commonsLang = new Coordinate('commons-lang', 'commons-lang', '2.6')
+    private static final def lombok = new Coordinate('org.projectlombok', 'lombok', '1.16.20')
+    private static final def junit = new Coordinate('junit', 'junit', '4.12')
+
+    def main = '''
+            import org.apache.commons.logging.Log;
+            import org.apache.commons.logging.LogFactory;
+            public class Main {
+                public static void main(String[] args) {
+                    Log log = LogFactory.getLog(Main.class);
+                    log.info("foo");
+                }
+            }
+        '''
+
+    def setup() {
+        definePluginOutsideOfPluginBlock = true
+    }
+
+    def 'simple - add undeclared dependencies as first-orders'() {
+        given:
+        def repo = new File(projectDir, 'repo')
+        repo.mkdirs()
+
+        def samplePom = new Pom(sample.getGroup(), sample.getArtifact(), sample.getVersion())
+        samplePom.addDependency(commonsLogging.getGroup(), commonsLogging.getArtifact(), commonsLogging.getVersion())
+        ArtifactHelpers.setupSamplePomWith(repo, sample, samplePom.generate())
+        ArtifactHelpers.setupSampleJar(repo, sample)
+
+        setupBuildGradleSimpleSetup(repo)
+        buildFile << """\
+            dependencies {
+            ${deps.collect { "    compile '$it'" }.join('\n')}
+            }
+            """.stripIndent()
+
+        when:
+
+        createJavaSourceFile(main)
+
+        then:
+        def result = runTasksSuccessfully('fixGradleLint')
+
+        result.output.contains('fixed')
+        def dependencies = dependencies(buildFile)
+        for (def expectedDependency : expected) {
+            assert dependencies.contains(expectedDependency.toString())
+        }
+
+        where:
+        deps     | expected
+        [sample] | [sample, commonsLogging]
+    }
+
+    def 'adds dependencies alphabetically'() {
+        given:
+        def repo = new File(projectDir, 'repo')
+        repo.mkdirs()
+
+        def samplePom = new Pom(sample.getGroup(), sample.getArtifact(), sample.getVersion())
+        samplePom.addDependency(lombok.getGroup(), lombok.getArtifact(), lombok.getVersion())
+        samplePom.addDependency(junit.getGroup(), junit.getArtifact(), junit.getVersion())
+        samplePom.addDependency(commonsLogging.getGroup(), commonsLogging.getArtifact(), commonsLogging.getVersion())
+        samplePom.addDependency(commonsLang.getGroup(), commonsLang.getArtifact(), commonsLang.getVersion())
+        ArtifactHelpers.setupSamplePomWith(repo, sample, samplePom.generate())
+        ArtifactHelpers.setupSampleJar(repo, sample)
+
+        setupBuildGradleSimpleSetup(repo)
+        buildFile << """\
+            dependencies {
+            ${deps.collect { "    compile '$it'" }.join('\n')}
+            }
+            """.stripIndent()
+
+        when:
+
+        createJavaSourceFile("""\
+            import lombok.Value;
+            import org.apache.commons.lang.StringUtils;
+            import org.apache.commons.logging.Log;
+            import org.apache.commons.logging.LogFactory;            
+            public final class Main {
+                public static void main(String[] args) {
+                    Log log = LogFactory.getLog(Main.class);
+                    final Friend f = new Friend("bat", "bar");
+                    if(!StringUtils.isEmpty(f.getFirstName())) {
+                        log.info(f.getFirstName());
+                    }
+                }
+                @Value
+                private static class Friend {
+                    private final String firstName;
+                    private final String lastName;
+                }
+            }
+            """.stripIndent())
+
+        createJavaTestFile(projectDir, '''
+            import static org.junit.Assert.*;
+            import org.junit.Test;
+
+            public class MainTest {
+                @Test
+                public void performTest() {
+                    assertEquals(1, 1);
+                }
+            }
+        '''.stripIndent())
+
+        then:
+        def result = runTasksSuccessfully('fixGradleLint')
+
+        result.output.contains('fixed')
+        def dependencies = dependencies(buildFile)
+        for (def expectedDependency : expected) {
+            assert dependencies.contains(expectedDependency.toString())
+        }
+
+        def expectedOrderingForDependencies = """\
+            dependencies {
+                compile '${sample.toString()}'
+                compile '${commonsLang.toString()}'
+                compile '${commonsLogging.toString()}'
+                testCompile '${junit.toString()}'
+            }
+            """.stripIndent()
+        buildFile.text.contains(expectedOrderingForDependencies)
+
+        where:
+        deps     | expected
+        [sample] | [sample, commonsLogging, junit, commonsLang]
+    }
+
+    def 'adds from even transitive runtime scope'() {
+        given:
+        def repo = new File(projectDir, 'repo')
+        repo.mkdirs()
+
+        def samplePom = new Pom(sample.getGroup(), sample.getArtifact(), sample.getVersion())
+        samplePom.addDependency(commonsLogging.getGroup(), commonsLogging.getArtifact(), commonsLogging.getVersion())
+        ArtifactHelpers.setupSamplePomWith(repo, sample, samplePom.generate())
+        ArtifactHelpers.setupSampleJar(repo, sample)
+
+        setupBuildGradleSimpleSetup(repo)
+        buildFile << """\
+            dependencies {
+            ${deps.collect { "    compile '$it'" }.join('\n')}
+            }
+            """.stripIndent()
+
+        when:
+
+        createJavaSourceFile(main)
+
+        then:
+        def result = runTasksSuccessfully('fixGradleLint')
+
+        result.output.contains('fixed')
+        def dependencies = dependencies(buildFile)
+        for (def expectedDependency : expected) {
+            assert dependencies.contains(expectedDependency.toString())
+        }
+        assert buildFile.text.contains("compile '${commonsLogging.toString()}'")
+
+        where:
+        deps     | expected
+        [sample] | [sample, commonsLogging]
+    }
+
+    def 'when defined dynamically, resolve to static version'() {
+        given:
+        def repo = new File(projectDir, 'repo')
+        repo.mkdirs()
+
+        def samplePom = new Pom(sample.getGroup(), sample.getArtifact(), sample.getVersion())
+        samplePom.addDependency(commonsLogging.getGroup(), commonsLogging.getArtifact(), 'latest.release')
+        ArtifactHelpers.setupSamplePomWith(repo, sample, samplePom.generate())
+        ArtifactHelpers.setupSampleJar(repo, sample)
+
+        setupBuildGradleSimpleSetup(repo)
+        buildFile << """\
+            dependencies {
+            ${deps.collect { "    compile '$it'" }.join('\n')}
+            }
+            """.stripIndent()
+
+        when:
+
+        createJavaSourceFile(main)
+
+        then:
+        def result = runTasksSuccessfully('fixGradleLint')
+
+        result.output.contains('fixed')
+        def dependencies = dependencies(buildFile)
+        for (def expectedDependency : expected) {
+            assert dependencies.contains(expectedDependency.toString())
+        }
+
+        where:
+        deps     | expected
+        [sample] | [sample, commonsLogging]
+    }
+
+    def 'adds when required in test code'() {
+        given:
+        def repo = new File(projectDir, 'repo')
+        repo.mkdirs()
+
+        def samplePom = new Pom(sample.getGroup(), sample.getArtifact(), sample.getVersion())
+        samplePom.addDependency(junit.getGroup(), junit.getArtifact(), junit.getVersion())
+        ArtifactHelpers.setupSamplePomWith(repo, sample, samplePom.generate())
+        ArtifactHelpers.setupSampleJar(repo, sample)
+
+        setupBuildGradleSimpleSetup(repo)
+        buildFile << """\
+            dependencies {
+            ${deps.collect { "    testCompile '$it'" }.join('\n')}
+            }
+            """.stripIndent()
+
+        when:
+        createJavaTestFile(projectDir, '''
+            import static org.junit.Assert.*;
+            import org.junit.Test;
+
+            public class MainTest {
+                @Test
+                public void performTest() {
+                    assertEquals(1, 1);
+                }
+            }
+        '''.stripIndent())
+
+        then:
+        def result = runTasksSuccessfully('fixGradleLint')
+
+        result.output.contains('fixed')
+        def dependencies = dependencies(buildFile)
+        for (def expectedDependency : expected) {
+            assert dependencies.contains(expectedDependency.toString())
+            assert buildFile.text.contains("testCompile '${expectedDependency.toString()}'")
+        }
+
+        where:
+        deps     | expected
+        [sample] | [sample, junit]
+    }
+
+    def 'adds when required through the type hierarchy '() {
+        def repo = new File(projectDir, 'repo')
+        repo.mkdirs()
+
+        def samplePom = new Pom(sample.getGroup(), sample.getArtifact(), sample.getVersion())
+        samplePom.addDependency(commonsLogging.getGroup(), commonsLogging.getArtifact(), commonsLogging.getVersion())
+        ArtifactHelpers.setupSamplePomWith(repo, sample, samplePom.generate())
+        ArtifactHelpers.setupSampleJar(repo, sample)
+
+        setupBuildGradleSimpleSetup(repo)
+        buildFile << """\
+            dependencies {
+            ${deps.collect { "    compile '$it'" }.join('\n')}
+            }
+            """.stripIndent()
+
+        when:
+        createJavaSourceFile('''
+            import org.apache.commons.logging.impl.NoOpLog;
+
+            public abstract class Main extends NoOpLog {
+            }
+        '''.stripIndent())
+
+        then:
+        def result = runTasksSuccessfully('fixGradleLint')
+
+        result.output.contains('fixed')
+        def dependencies = dependencies(buildFile)
+        for (def expectedDependency : expected) {
+            assert dependencies.contains(expectedDependency.toString())
+        }
+
+        where:
+        deps     | expected
+        [sample] | [sample, commonsLogging]
+    }
+
+    def 'adds when defining plugin in plugin block'() {
+        definePluginOutsideOfPluginBlock = false
+        def repo = new File(projectDir, 'repo')
+        repo.mkdirs()
+
+        def samplePom = new Pom(sample.getGroup(), sample.getArtifact(), sample.getVersion())
+        samplePom.addDependency(commonsLogging.getGroup(), commonsLogging.getArtifact(), commonsLogging.getVersion())
+        ArtifactHelpers.setupSamplePomWith(repo, sample, samplePom.generate())
+        ArtifactHelpers.setupSampleJar(repo, sample)
+
+        when:
+        buildFile.text = """\
+            plugins {
+                id 'nebula.lint'
+                id 'java'
+            }
+
+            gradleLint.rules = ['undeclared-dependency']
+
+            repositories {
+                maven { url "${repo.toURI().toURL()}" }
+                mavenCentral()
+            }
+
+            dependencies {
+            ${deps.collect { "   compile '$it'" }.join('\n')}
+            }
+            """.stripIndent()
+
+        createJavaSourceFile(main)
+
+        then:
+        def result = runTasksSuccessfully('fixGradleLint')
+
+        result.output.contains('fixed')
+        def dependencies = dependencies(buildFile)
+        for (def expectedDependency : expected) {
+            assert dependencies.contains(expectedDependency.toString())
+        }
+
+        where:
+        deps     | expected
+        [sample] | [sample, commonsLogging]
+    }
+
+    def 'when defined in allprojects block - adds dependencies to smallest scope for subprojects'() {
+        given:
+        def repo = new File(projectDir, 'repo')
+        repo.mkdirs()
+
+        def samplePom = new Pom(sample.getGroup(), sample.getArtifact(), sample.getVersion())
+        samplePom.addDependency(commonsLogging.getGroup(), commonsLogging.getArtifact(), commonsLogging.getVersion())
+        ArtifactHelpers.setupSamplePomWith(repo, sample, samplePom.generate())
+        ArtifactHelpers.setupSampleJar(repo, sample)
+
+        def dependencyBlock = """\
+            dependencies {
+            ${deps.collect { "    compile '$it'" }.join('\n')}
+            }
+            """.stripIndent()
+        setupBuildGradleSetupForAllprojects(repo, dependencyBlock)
+
+        addSubproject('sub1', """\
+            dependencies {
+            }
+            """.stripIndent())
+
+        when:
+
+        createJavaSourceFile(new File(projectDir.toString() + File.separator + 'sub1'), main)
+
+        then:
+        def result = runTasksSuccessfully('fixGradleLint')
+
+        result.output.contains('fixed')
+        assert dependencies(buildFile).contains(sample.toString())
+        assert dependencies(new File(projectDir, 'sub1/build.gradle')).contains(commonsLogging.toString())
+
+        where:
+        deps     | expected
+        [sample] | [sample, commonsLogging]
+    }
+
+    def 'when defined in parent build file - adds dependencies to smallest scope for subprojects'() {
+        given:
+        def repo = new File(projectDir, 'repo')
+        repo.mkdirs()
+
+        def samplePom = new Pom(sample.getGroup(), sample.getArtifact(), sample.getVersion())
+        samplePom.addDependency(commonsLogging.getGroup(), commonsLogging.getArtifact(), commonsLogging.getVersion())
+        ArtifactHelpers.setupSamplePomWith(repo, sample, samplePom.generate())
+        ArtifactHelpers.setupSampleJar(repo, sample)
+
+        setupBuildGradleSetupForAllprojects(repo)
+        buildFile << """\
+            subprojects {
+                dependencies {
+                ${deps.collect { "    compile '$it'" }.join('\\n')}
+                }
+            }
+            """.stripIndent()
+
+        addSubproject('sub1', """\
+            dependencies {
+            }
+            """.stripIndent())
+
+        when:
+
+        createJavaSourceFile(new File(projectDir.toString() + File.separator + 'sub1'), main)
+
+        then:
+        def result = runTasksSuccessfully('fixGradleLint')
+
+        result.output.contains('fixed')
+        assert dependencies(buildFile).contains(sample.toString())
+        assert dependencies(new File(projectDir, 'sub1/build.gradle')).contains(commonsLogging.toString())
+
+        where:
+        deps     | expected
+        [sample] | [sample, commonsLogging]
+    }
+
+    def 'when defined in subproject build files - adds dependencies to smallest scope for subprojects'() {
+        given:
+        def repo = new File(projectDir, 'repo')
+        repo.mkdirs()
+
+        def samplePom = new Pom(sample.getGroup(), sample.getArtifact(), sample.getVersion())
+        samplePom.addDependency(commonsLogging.getGroup(), commonsLogging.getArtifact(), commonsLogging.getVersion())
+        ArtifactHelpers.setupSamplePomWith(repo, sample, samplePom.generate())
+        ArtifactHelpers.setupSampleJar(repo, sample)
+
+        setupBuildGradleSetupForAllprojects(repo)
+
+        addSubproject('sub1', """\
+            dependencies {
+            ${deps.collect { "    compile '$it'" }.join('\n')}
+            }
+            """.stripIndent())
+
+        addSubproject('sub2', """\
+            dependencies {
+            ${deps.collect { "    compile '$it'" }.join('\n')}
+            }
+            """.stripIndent())
+
+        when:
+
+        createJavaSourceFile(new File(projectDir.toString() + File.separator + 'sub1'), main)
+        createJavaSourceFile(new File(projectDir.toString() + File.separator + 'sub2'), main)
+
+        then:
+        def result = runTasksSuccessfully('fixGradleLint')
+
+        result.output.contains('fixed')
+
+        def sub1Build = new File(projectDir, 'sub1/build.gradle')
+        def sub1Dependencies = dependencies(sub1Build)
+        for (def expectedDependency : expected) {
+            assert sub1Dependencies.contains(expectedDependency.toString())
+        }
+
+        def sub2Build = new File(projectDir, 'sub2/build.gradle')
+        def sub2Dependencies = dependencies(sub2Build)
+        for (def expectedDependency : expected) {
+            assert sub2Dependencies.contains(expectedDependency.toString())
+        }
+        where:
+        deps     | expected
+        [sample] | [sample, commonsLogging]
+    }
+
+    def 'handles empty subprojects build file'() {
+        given:
+        def repo = new File(projectDir, 'repo')
+        repo.mkdirs()
+
+        def samplePom = new Pom(sample.getGroup(), sample.getArtifact(), sample.getVersion())
+        samplePom.addDependency(commonsLogging.getGroup(), commonsLogging.getArtifact(), commonsLogging.getVersion())
+        ArtifactHelpers.setupSamplePomWith(repo, sample, samplePom.generate())
+        ArtifactHelpers.setupSampleJar(repo, sample)
+
+        setupBuildGradleSetupForAllprojects(repo)
+        buildFile << """\
+            subprojects {
+                dependencies {
+                ${deps.collect { "    compile '$it'" }.join('\\n')}
+                }
+            }
+            """.stripIndent()
+        addSubproject('sub1', "")
+
+        when:
+
+        createJavaSourceFile(new File(projectDir.toString() + File.separator + 'sub1'), main)
+
+        then:
+        def firstResult = runTasksSuccessfully('fixGradleLint')
+
+        firstResult.output.contains('you require a dependencies block')
+
+        when:
+        def secondResult = runTasksSuccessfully('fixGradleLint')
+
+        then:
+        secondResult
+        secondResult.output.contains('fixed')
+        assert dependencies(buildFile).contains(sample.toString())
+        assert dependencies(new File(projectDir, 'sub1/build.gradle')).contains(commonsLogging.toString())
+
+        where:
+        deps << [sample]
+    }
+
+    def 'when using compileOnly configuration, transitives are resolved before linting so no changes are made'() {
+        given:
+        def repo = new File(projectDir, 'repo')
+        repo.mkdirs()
+
+        def samplePom = new Pom(sample.getGroup(), sample.getArtifact(), sample.getVersion())
+        samplePom.addDependency(lombok.getGroup(), lombok.getArtifact(), lombok.getVersion())
+        ArtifactHelpers.setupSamplePomWith(repo, sample, samplePom.generate())
+        ArtifactHelpers.setupSampleJar(repo, sample)
+
+        setupBuildGradleSimpleSetup(repo)
+        buildFile << """\
+            dependencies {
+            ${deps.collect { "    compileOnly '$it'" }.join('\n')}
+            }
+            """.stripIndent()
+
+        when:
+
+        createJavaSourceFile("""\
+            import lombok.Value;
+            public final class Main {
+                public static void main(String[] args) {
+                    final Friend f = new Friend("bat", "bar");
+                    System.out.println(f.getFirstName());
+                }
+                @Value
+                private static class Friend {
+                    private final String firstName;
+                    private final String lastName;
+                }
+            }
+            """.stripIndent())
+
+        then:
+        def result = runTasksSuccessfully('fixGradleLint')
+
+        def dependencies = dependencies(buildFile)
+        for (def expectedDependency : expected) {
+            assert dependencies.contains(expectedDependency.toString())
+            assert buildFile.text.contains("compileOnly '${expectedDependency.toString()}'")
+        }
+
+        where:
+        deps     | expected
+        [sample] | [sample]
+    }
+
+    def setupBuildGradleSimpleSetup(File repo) {
+        buildFile << """\
+            apply plugin: 'nebula.lint'
+            apply plugin: 'java'
+            gradleLint.rules = ['undeclared-dependency']
+            repositories {
+                maven { url "${repo.toURI().toURL()}" }
+                mavenCentral()
+            }
+            """.stripIndent()
+    }
+
+    def setupBuildGradleSetupForAllprojects(File repo, String dependencyBlock = '') {
+        buildFile << """\
+            allprojects {
+                apply plugin: 'nebula.lint'
+                apply plugin: 'java'
+                gradleLint.rules = ['undeclared-dependency']
+                repositories {
+                    maven { url "${repo.toURI().toURL()}" }
+                    mavenCentral()
+                }
+            """.stripIndent()
+        buildFile << dependencyBlock
+        buildFile << """\
+            }
+            """.stripIndent()
+    }
+}

--- a/src/test/groovy/com/netflix/nebula/lint/rule/dependency/UnusedDependencyRuleSpec.groovy
+++ b/src/test/groovy/com/netflix/nebula/lint/rule/dependency/UnusedDependencyRuleSpec.groovy
@@ -16,7 +16,6 @@
 package com.netflix.nebula.lint.rule.dependency
 
 import com.netflix.nebula.lint.TestKitSpecification
-import spock.lang.Ignore
 import spock.lang.Issue
 import spock.lang.Unroll
 
@@ -63,6 +62,7 @@ class UnusedDependencyRuleSpec extends TestKitSpecification {
 
         then:
         runTasksSuccessfully('compileJava', 'fixGradleLint')
+
         dependencies(buildFile) == expected
 
         where:


### PR DESCRIPTION
All compile-time dependencies should be declared as first order dependencies in the project. 

This lint rule ensures that (previously transitive) dependencies needed for compilation are added to the needed configurations, with the smallest scope, i.e. only added to a subproject build filed and not to an `allprojects` or `subprojects` block in the parent build file. 

This behavior is required for Gradle 4.5+ when experimental features for improved pom support are enabled, and will be required with Gradle 5.0.