### PR TITLE
Support Java Library Plugin

### DIFF
--- a/src/main/groovy/com/netflix/nebula/lint/rule/dependency/AbstractDuplicateDependencyClassRule.groovy
+++ b/src/main/groovy/com/netflix/nebula/lint/rule/dependency/AbstractDuplicateDependencyClassRule.groovy
@@ -42,11 +42,14 @@ abstract class AbstractDuplicateDependencyClassRule extends GradleLintRule imple
     @Override
     protected void visitClassComplete(ClassNode node) {
         for (Configuration conf : directlyUsedConfigurations) {
-            if (DependencyService.forProject(project).isResolved(conf)) {
+            def dependencyService = DependencyService.forProject(project)
+            if (dependencyService.resolvedConfigurations().contains(conf)) {
                 def moduleIds = moduleIds(conf)
-                def dependencyService = Class.forName('com.netflix.nebula.lint.rule.dependency.DuplicateDependencyService').newInstance(project)
-                def checkForDuplicates = dependencyService.class.methods.find { it.name == 'violationsForModules' }
-                def violations = checkForDuplicates.invoke(dependencyService, moduleIds, conf, ignoredDependencies) as List<String>
+                def duplicateDependencyService = Class.forName('com.netflix.nebula.lint.rule.dependency.DuplicateDependencyService').newInstance(project)
+                def checkForDuplicates = duplicateDependencyService.class.methods.find {
+                    it.name == 'violationsForModules'
+                }
+                def violations = checkForDuplicates.invoke(duplicateDependencyService, moduleIds, conf, ignoredDependencies) as List<String>
                 violations.each { message ->
                     addBuildLintViolation(message)
                 }

--- a/src/main/groovy/com/netflix/nebula/lint/rule/dependency/DependencyService.groovy
+++ b/src/main/groovy/com/netflix/nebula/lint/rule/dependency/DependencyService.groovy
@@ -120,6 +120,10 @@ class DependencyService {
         return project.configurations.findAll { isResolvable(it) }
     }
 
+    Set<Configuration> resolvedConfigurations() {
+        return resolvableConfigurations().findAll { isResolved(it) }
+    }
+
     @SuppressWarnings("GrMethodMayBeStatic") // Static memoization will leak
     @Memoized
     JarContents jarContents(File file) {
@@ -348,6 +352,7 @@ class DependencyService {
         return transitives
     }
 
+    // Think about using resolvedConfigurations() instead
     boolean isResolved(String conf) {
         try {
             return isResolved(project.configurations.getByName(conf))
@@ -356,6 +361,7 @@ class DependencyService {
         }
     }
 
+    // Think about using resolvedConfigurations() instead
     boolean isResolved(Configuration conf) {
         // Gradle does not properly propagate the resolved state down configuration hierarchies
         conf.state == Configuration.State.RESOLVED ||

--- a/src/main/groovy/com/netflix/nebula/lint/rule/dependency/DependencyService.groovy
+++ b/src/main/groovy/com/netflix/nebula/lint/rule/dependency/DependencyService.groovy
@@ -120,7 +120,12 @@ class DependencyService {
         return project.configurations.findAll { isResolvable(it) }
     }
 
-    Set<Configuration> resolvedConfigurations() {
+    /**
+     * Projects previously using {@link #resolvableConfigurations()} or
+     * checking configurations individually with {@link #isResolved()}
+     * will likely want to use this method
+     */
+    Set<Configuration> resolvableAndResolvedConfigurations() {
         return resolvableConfigurations().findAll { isResolved(it) }
     }
 
@@ -352,7 +357,6 @@ class DependencyService {
         return transitives
     }
 
-    // Think about using resolvedConfigurations() instead
     boolean isResolved(String conf) {
         try {
             return isResolved(project.configurations.getByName(conf))
@@ -361,7 +365,6 @@ class DependencyService {
         }
     }
 
-    // Think about using resolvedConfigurations() instead
     boolean isResolved(Configuration conf) {
         // Gradle does not properly propagate the resolved state down configuration hierarchies
         conf.state == Configuration.State.RESOLVED ||

--- a/src/main/groovy/com/netflix/nebula/lint/rule/dependency/OverriddenDependencyVersionRule.groovy
+++ b/src/main/groovy/com/netflix/nebula/lint/rule/dependency/OverriddenDependencyVersionRule.groovy
@@ -16,10 +16,17 @@ class OverriddenDependencyVersionRule extends GradleLintRule implements GradleMo
 
     def selectorScheme = new DefaultVersionSelectorScheme(new DefaultVersionComparator())
 
+    def resolvableAndResolvedConfigurations
+
+    @Override
+    protected void beforeApplyTo() {
+        def dependencyService = DependencyService.forProject(project)
+        resolvableAndResolvedConfigurations = dependencyService.resolvableAndResolvedConfigurations()
+    }
+
     @Override
     void visitGradleDependency(MethodCallExpression call, String conf, GradleDependency dep) {
-        def dependencyService = DependencyService.forProject(project)
-        if (!dependencyService.resolvedConfigurations().collect { it.name }.contains(conf)) {
+        if (!resolvableAndResolvedConfigurations.collect { it.name }.contains(conf)) {
             return // we won't slow down the build by resolving the configuration if it hasn't been already
         }
         

--- a/src/main/groovy/com/netflix/nebula/lint/rule/dependency/OverriddenDependencyVersionRule.groovy
+++ b/src/main/groovy/com/netflix/nebula/lint/rule/dependency/OverriddenDependencyVersionRule.groovy
@@ -18,7 +18,8 @@ class OverriddenDependencyVersionRule extends GradleLintRule implements GradleMo
 
     @Override
     void visitGradleDependency(MethodCallExpression call, String conf, GradleDependency dep) {
-        if(!DependencyService.forProject(project).isResolved(conf)) {
+        def dependencyService = DependencyService.forProject(project)
+        if (!dependencyService.resolvedConfigurations().collect { it.name }.contains(conf)) {
             return // we won't slow down the build by resolving the configuration if it hasn't been already
         }
         

--- a/src/main/groovy/com/netflix/nebula/lint/rule/dependency/UnusedDependencyRule.groovy
+++ b/src/main/groovy/com/netflix/nebula/lint/rule/dependency/UnusedDependencyRule.groovy
@@ -25,7 +25,7 @@ class UnusedDependencyRule extends GradleLintRule implements GradleModelAware {
 
     @Override
     void visitGradleDependency(MethodCallExpression call, String conf, GradleDependency dep) {
-        if(!dependencyService.isResolved(conf)) {
+        if (!dependencyService.isResolved(conf)) {
             return // we won't slow down the build by resolving the configuration if it hasn't been already
         }
 
@@ -35,7 +35,7 @@ class UnusedDependencyRule extends GradleLintRule implements GradleModelAware {
             if(conf == 'compileOnly') {
                 compileOnlyDependencies.add(mid)
             }
-            
+
             if (!dependencyService.isRuntime(conf) && dependencyService.isResolvable(conf)) {
                 def jarContents = dependencyService.jarContents(mid)
                 if (!jarContents) {
@@ -73,7 +73,7 @@ class UnusedDependencyRule extends GradleLintRule implements GradleModelAware {
                                 .delete(call)
                     }
                 }
-            } else if(conf != 'compileOnly') {
+            } else if (conf != 'compileOnly') {
                 runtimeDependencyDefinitions[mid] = call
             }
         }

--- a/src/test/groovy/com/netflix/nebula/lint/TestKitSpecification.groovy
+++ b/src/test/groovy/com/netflix/nebula/lint/TestKitSpecification.groovy
@@ -135,12 +135,26 @@ abstract class TestKitSpecification extends Specification {
         createJavaFile(projectDir, source, 'src/main/java')
     }
 
+    def createJavaSourceFile(File projectDir) {
+        createJavaSourceFile(projectDir, 'public class Main {}')
+    }
+
     def createJavaTestFile(File projectDir, String source) {
         createJavaFile(projectDir, source, 'src/test/java')
     }
 
     def createJavaTestFile(String source) {
         createJavaTestFile(projectDir, source)
+    }
+
+    def createJavaTestFile(File projectDir) {
+        createJavaTestFile(projectDir, '''
+            import org.junit.Test;
+            public class Test1 {
+                @Test
+                public void test() {}
+            }
+        '''.stripIndent())
     }
 
     def createJavaFile(File projectDir, String source, String sourceFolderPath) {

--- a/src/test/groovy/com/netflix/nebula/lint/rule/SupportJavaLibrarySpec.groovy
+++ b/src/test/groovy/com/netflix/nebula/lint/rule/SupportJavaLibrarySpec.groovy
@@ -1,0 +1,81 @@
+/**
+ *
+ *  Copyright 2018 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+
+package com.netflix.nebula.lint.rule
+
+import com.netflix.nebula.lint.TestKitSpecification
+
+
+class SupportJavaLibrarySpec extends TestKitSpecification {
+    def 'handles java-library plugin'() {
+        given:
+        setupWithJavaLibraryAndAllRules()
+
+        when:
+        def result = runTasksSuccessfully('fixGradleLint')
+
+        then:
+        !result.output.contains('This project contains lint violations.')
+    }
+
+    def 'verify rules are working - testing undeclared dependency'() {
+        given:
+        setupWithJavaLibraryAndAllRules(true)
+
+        when:
+        def result = runTasksSuccessfully('fixGradleLint')
+
+        then:
+        result.output.contains('undeclared-dependency')
+        result.output.contains('This project contains lint violations.')
+    }
+
+    private def setupWithJavaLibraryAndAllRules(boolean undeclaredDependency = false) {
+        definePluginOutsideOfPluginBlock = true
+
+        def configuration
+        if (undeclaredDependency) {
+            configuration = 'implementation'
+        } else {
+            configuration = 'testCompile'
+        }
+
+        buildFile << """
+        allprojects {
+            apply plugin: 'nebula.lint'
+            apply plugin: 'java-library'
+            dependencies {
+                ${configuration} 'junit:junit:4.11'
+            }
+            gradleLint.rules=['all-dependency']
+            repositories {
+                mavenCentral()
+            }
+        }
+        """.stripIndent()
+
+        addSubproject('sub1', """
+            dependencies {
+                api 'com.squareup.retrofit2:retrofit:2.4.0'
+                implementation 'com.squareup.okhttp3:okhttp:3.10.0'
+            }
+            """.stripIndent())
+        createJavaSourceFile(new File(projectDir.toString() + '/sub1'))
+        createJavaTestFile(new File(projectDir.toString() + '/sub1'))
+    }
+}

--- a/src/test/groovy/com/netflix/nebula/lint/rule/dependency/DependencyServiceSpec.groovy
+++ b/src/test/groovy/com/netflix/nebula/lint/rule/dependency/DependencyServiceSpec.groovy
@@ -319,9 +319,9 @@ class DependencyServiceSpec extends TestKitSpecification {
             
             import com.netflix.nebula.lint.rule.dependency.*
             
-            task resolvedConfigurations << {
-              new File(projectDir, "resolvedConfigurations.txt").text = DependencyService.forProject(project)
-                .resolvedConfigurations()
+            task resolvableAndResolvedConfigurations << {
+              new File(projectDir, "resolvableAndResolvedConfigurations.txt").text = DependencyService.forProject(project)
+                .resolvableAndResolvedConfigurations()
                 .join('\\n')
             }
             """.stripIndent()
@@ -335,7 +335,7 @@ class DependencyServiceSpec extends TestKitSpecification {
         }
 
         when:
-        def resolvedConfigurations = dependencyService.resolvedConfigurations()
+        def resolvedConfigurations = dependencyService.resolvableAndResolvedConfigurations()
 
         then:
         def configurationNames = resolvedConfigurations.collect { conf -> conf.getName() }

--- a/src/test/groovy/com/netflix/nebula/lint/rule/dependency/DependencyServiceSpec.groovy
+++ b/src/test/groovy/com/netflix/nebula/lint/rule/dependency/DependencyServiceSpec.groovy
@@ -288,4 +288,76 @@ class DependencyServiceSpec extends TestKitSpecification {
         ['web:coreContents']                    | []
         ['web:assemble', 'web:coreContents']    | ['A']
     }
+
+    def 'resolved configurations returns lists of configurations that are resolvable and resolved'() {
+        given:
+        definePluginOutsideOfPluginBlock = true
+        def dependency = 'commons-lang:commons-lang:latest.release'
+
+        buildFile << """
+            apply plugin: 'java-library'
+
+            repositories { jcenter() }
+
+            dependencies {
+                compile '${dependency}'
+                testCompile '${dependency}'
+
+                implementation '${dependency}'
+                testImplementation '${dependency}'
+
+                apiElements '${dependency}'
+
+                runtimeElements '${dependency}'
+
+                runtime '${dependency}'
+                testRuntime '${dependency}'
+
+                runtimeOnly '${dependency}'
+                testRuntimeOnly '${dependency}'
+            }
+            
+            import com.netflix.nebula.lint.rule.dependency.*
+            
+            task resolvedConfigurations << {
+              new File(projectDir, "resolvedConfigurations.txt").text = DependencyService.forProject(project)
+                .resolvedConfigurations()
+                .join('\\n')
+            }
+            """.stripIndent()
+
+        createJavaSourceFile('public class Main {}')
+        createJavaTestFile('public class TestMain {}')
+
+        def dependencyService = DependencyService.forProject(project)
+        dependencyService.resolvableConfigurations().each { resolvableConf ->
+            resolvableConf.resolve()
+        }
+
+        when:
+        def resolvedConfigurations = dependencyService.resolvedConfigurations()
+
+        then:
+        def configurationNames = resolvedConfigurations.collect { conf -> conf.getName() }
+
+        configurationNames.size() > 0
+
+        // sample the configurations
+        configurationNames.contains('compile')
+        configurationNames.contains('testCompile')
+
+        !configurationNames.contains('implementation')
+        !configurationNames.contains('testImplementation')
+
+        !configurationNames.contains('apiElements')
+        !configurationNames.contains('runtimeElements')
+
+        configurationNames.contains('runtime')
+        configurationNames.contains('testRuntime')
+
+        !configurationNames.contains('runtimeOnly')
+        !configurationNames.contains('testRuntimeOnly')
+
+        // and more!
+    }
 }


### PR DESCRIPTION
Support the [Java Library Plugin](https://docs.gradle.org/current/userguide/java_library_plugin.html) by not interrogating dependency configurations that [cannot be resolved](https://docs.gradle.org/current/userguide/java_library_plugin.html#sec:java_library_configurations_graph). 