### PR TITLE
Deprecated dependency configuration rule

### DIFF
--- a/src/main/groovy/com/netflix/nebula/lint/rule/dependency/DependencyViolationUtil.groovy
+++ b/src/main/groovy/com/netflix/nebula/lint/rule/dependency/DependencyViolationUtil.groovy
@@ -1,0 +1,19 @@
+package com.netflix.nebula.lint.rule.dependency
+
+import com.netflix.nebula.lint.GradleViolation
+import com.netflix.nebula.lint.rule.GradleDependency
+import org.codehaus.groovy.ast.expr.MethodCallExpression
+
+class DependencyViolationUtil {
+
+    static void replaceDependencyConfiguration(GradleViolation violation, MethodCallExpression call, String conf, GradleDependency dep) {
+        violation.replaceWith(call, "$conf '${dep.toNotation()}'")
+    }
+
+    static void replaceDependencyConfiguration(GradleViolation violation, MethodCallExpression call, String conf) {
+        List<String> lines = violation.files.text.readLines()
+        List<String> closureLines = lines.subList(call.lineNumber-1, call.lastLineNumber)
+        String codeBlock = closureLines.join('\n').trim()
+        violation.replaceWith(call, codeBlock.replace(call.methodAsString, conf))
+    }
+}

--- a/src/main/groovy/com/netflix/nebula/lint/rule/dependency/DependencyViolationUtil.groovy
+++ b/src/main/groovy/com/netflix/nebula/lint/rule/dependency/DependencyViolationUtil.groovy
@@ -6,6 +6,10 @@ import org.codehaus.groovy.ast.expr.MethodCallExpression
 
 class DependencyViolationUtil {
 
+    static void replaceProjectDependencyConfiguration(GradleViolation violation, MethodCallExpression call, String configuration, String project) {
+        violation.replaceWith(call, "$configuration project('$project')")
+    }
+
     static void replaceDependencyConfiguration(GradleViolation violation, MethodCallExpression call, String conf, GradleDependency dep) {
         violation.replaceWith(call, "$conf '${dep.toNotation()}'")
     }

--- a/src/main/groovy/com/netflix/nebula/lint/rule/dependency/DeprecatedDependencyConfigurationRule.groovy
+++ b/src/main/groovy/com/netflix/nebula/lint/rule/dependency/DeprecatedDependencyConfigurationRule.groovy
@@ -1,5 +1,6 @@
 package com.netflix.nebula.lint.rule.dependency
 
+import com.netflix.nebula.interop.GradleKt
 import com.netflix.nebula.lint.GradleViolation
 import com.netflix.nebula.lint.rule.GradleDependency
 import com.netflix.nebula.lint.rule.GradleLintRule
@@ -14,6 +15,9 @@ class DeprecatedDependencyConfigurationRule extends GradleLintRule implements Gr
             "testCompile": "testImplementation",
             "runtime": "runtimeOnly"
     ]
+
+    private final String MINIMUM_GRADLE_VERSION = "4.7"
+
 
     @Override
     void visitAnyGradleDependency(MethodCallExpression call, String conf, GradleDependency dep) {
@@ -36,7 +40,7 @@ class DeprecatedDependencyConfigurationRule extends GradleLintRule implements Gr
     }
 
     private void handleDependencyVisit(MethodCallExpression call, String conf, GradleDependency dep) {
-        if(CONFIGURATION_REPLACEMENTS.containsKey(conf)) {
+        if(CONFIGURATION_REPLACEMENTS.containsKey(conf) && !GradleKt.versionLessThan(project.gradle, MINIMUM_GRADLE_VERSION)) {
             if (call.arguments.expressions.size() == 1) {
                 replaceSingleLineDependencyConfiguration(call, conf, dep)
             } else {

--- a/src/main/groovy/com/netflix/nebula/lint/rule/dependency/DeprecatedDependencyConfigurationRule.groovy
+++ b/src/main/groovy/com/netflix/nebula/lint/rule/dependency/DeprecatedDependencyConfigurationRule.groovy
@@ -1,0 +1,60 @@
+package com.netflix.nebula.lint.rule.dependency
+
+import com.netflix.nebula.lint.GradleViolation
+import com.netflix.nebula.lint.rule.GradleDependency
+import com.netflix.nebula.lint.rule.GradleLintRule
+import com.netflix.nebula.lint.rule.GradleModelAware
+import org.codehaus.groovy.ast.expr.MethodCallExpression
+
+class DeprecatedDependencyConfigurationRule extends GradleLintRule implements GradleModelAware {
+    String description = 'Replace deprecated configurations in dependencies'
+
+    private final Map CONFIGURATION_REPLACEMENTS = [
+            "compile": "implementation",
+            "testCompile": "testImplementation",
+            "runtime": "runtimeOnly"
+    ]
+
+    @Override
+    void visitAnyGradleDependency(MethodCallExpression call, String conf, GradleDependency dep) {
+        handleDependencyVisit(call, conf, dep)
+    }
+
+    @Override
+    void visitGradleDependency(MethodCallExpression call, String conf, GradleDependency dep) {
+        handleDependencyVisit(call, conf, dep)
+    }
+
+    @Override
+    void visitSubprojectGradleDependency(MethodCallExpression call, String conf, GradleDependency dep) {
+        handleDependencyVisit(call, conf, dep)
+    }
+
+    @Override
+    void visitAllprojectsGradleDependency(MethodCallExpression call, String conf, GradleDependency dep) {
+        handleDependencyVisit(call, conf, dep)
+    }
+
+    private void handleDependencyVisit(MethodCallExpression call, String conf, GradleDependency dep) {
+        if(CONFIGURATION_REPLACEMENTS.containsKey(conf)) {
+            if (call.arguments.expressions.size() == 1) {
+                replaceSingleLineDependencyConfiguration(call, conf, dep)
+            } else {
+                replaceMultiLineDependencyConfiguration(call, conf)
+            }
+        }
+    }
+
+
+    private void replaceSingleLineDependencyConfiguration(MethodCallExpression call, String conf, GradleDependency dep) {
+        String configurationReplacement = CONFIGURATION_REPLACEMENTS.get(conf)
+        GradleViolation violation = addBuildLintViolation("Configuration $conf has been deprecated and should be replaced with $configurationReplacement", call)
+        DependencyViolationUtil.replaceDependencyConfiguration(violation, call, configurationReplacement, dep)
+    }
+
+    private void replaceMultiLineDependencyConfiguration(MethodCallExpression call, String conf) {
+        String configurationReplacement = CONFIGURATION_REPLACEMENTS.get(conf)
+        GradleViolation violation = addBuildLintViolation("Configuration $conf has been deprecated and should be replaced with $configurationReplacement", call)
+        DependencyViolationUtil.replaceDependencyConfiguration(violation, call, configurationReplacement)
+    }
+}

--- a/src/main/groovy/com/netflix/nebula/lint/rule/dependency/DeprecatedDependencyConfigurationRule.groovy
+++ b/src/main/groovy/com/netflix/nebula/lint/rule/dependency/DeprecatedDependencyConfigurationRule.groovy
@@ -47,6 +47,10 @@ class DeprecatedDependencyConfigurationRule extends GradleLintRule implements Gr
         }
     }
 
+    /**
+     * Responsible for replacing configurations in project dependencies only
+     * @param call
+     */
     private void handleProjectDependencies(MethodCallExpression call) {
         List statements = call.arguments.expressions*.code*.statements.flatten().findAll  { it.expression instanceof MethodCallExpression }
         statements.each { statement ->

--- a/src/main/resources/META-INF/lint-rules/all-dependency.properties
+++ b/src/main/resources/META-INF/lint-rules/all-dependency.properties
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-includes=unused-exclude-by-conf,unused-exclude-by-dep,unused-dependency,duplicate-dependency-class,transitive-duplicate-dependency-class,overridden-dependency-version,recommended-versions,undeclared-dependency,multiproject-circular-dependency,deprecated-dependency-configuration
+includes=unused-exclude-by-conf,unused-exclude-by-dep,unused-dependency,duplicate-dependency-class,transitive-duplicate-dependency-class,overridden-dependency-version,recommended-versions,undeclared-dependency,multiproject-circular-dependencyn

--- a/src/main/resources/META-INF/lint-rules/all-dependency.properties
+++ b/src/main/resources/META-INF/lint-rules/all-dependency.properties
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-includes=unused-exclude-by-conf,unused-exclude-by-dep,unused-dependency,duplicate-dependency-class,transitive-duplicate-dependency-class,overridden-dependency-version,recommended-versions,undeclared-dependency,multiproject-circular-dependency
+includes=unused-exclude-by-conf,unused-exclude-by-dep,unused-dependency,duplicate-dependency-class,transitive-duplicate-dependency-class,overridden-dependency-version,recommended-versions,undeclared-dependency,multiproject-circular-dependency,deprecated-dependency-configuration

--- a/src/main/resources/META-INF/lint-rules/all-dependency.properties
+++ b/src/main/resources/META-INF/lint-rules/all-dependency.properties
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-includes=unused-exclude-by-conf,unused-exclude-by-dep,unused-dependency,duplicate-dependency-class,transitive-duplicate-dependency-class,overridden-dependency-version,recommended-versions,undeclared-dependency,multiproject-circular-dependencyn
+includes=unused-exclude-by-conf,unused-exclude-by-dep,unused-dependency,duplicate-dependency-class,transitive-duplicate-dependency-class,overridden-dependency-version,recommended-versions,undeclared-dependency,multiproject-circular-dependency

--- a/src/main/resources/META-INF/lint-rules/deprecated-dependency-configuration.properties
+++ b/src/main/resources/META-INF/lint-rules/deprecated-dependency-configuration.properties
@@ -1,0 +1,1 @@
+implementation-class=com.netflix.nebula.lint.rule.dependency.DeprecatedDependencyConfigurationRule

--- a/src/test/groovy/com/netflix/nebula/lint/rule/dependency/DependencyViolationUtilSpec.groovy
+++ b/src/test/groovy/com/netflix/nebula/lint/rule/dependency/DependencyViolationUtilSpec.groovy
@@ -1,0 +1,74 @@
+package com.netflix.nebula.lint.rule.dependency
+
+import com.netflix.nebula.lint.GradleViolation
+import com.netflix.nebula.lint.rule.BuildFiles
+import com.netflix.nebula.lint.rule.GradleDependency
+import org.codehaus.groovy.ast.expr.MethodCallExpression
+import org.junit.Rule
+import org.junit.rules.TestName
+import spock.lang.Specification
+import spock.lang.Subject
+
+@Subject(DependencyViolationUtil)
+class DependencyViolationUtilSpec extends Specification {
+
+    @Rule
+    final TestName testName = new TestName()
+
+    def 'replaces dependency configuration - single line'() {
+        setup:
+        GradleViolation mockViolation = Mock(GradleViolation)
+        MethodCallExpression mockMethodCallExpression = Mock(MethodCallExpression)
+        GradleDependency mockGradleDependency = Mock(GradleDependency)
+
+        when:
+        DependencyViolationUtil.replaceDependencyConfiguration(mockViolation, mockMethodCallExpression, "implementation", mockGradleDependency)
+
+        then:
+        1 * mockViolation.replaceWith(mockMethodCallExpression, "implementation 'example:foo:1.0.0'")
+        1 * mockGradleDependency.toNotation() >> 'example:foo:1.0.0'
+    }
+
+    def 'replaces dependency configuration - multi line'() {
+        setup:
+        File projectDir = new File("build/nebulatest/${this.class.canonicalName}/${testName.methodName.replaceAll(/\W+/, '-')}").absoluteFile
+        if (projectDir.exists()) {
+            projectDir.deleteDir()
+        }
+        projectDir.mkdirs()
+        File buildFile = new File(projectDir, "build.gradle")
+        buildFile << """
+            plugins {
+                id 'nebula.lint'
+                id 'java-library'
+            }
+
+            gradleLint.rules = ['deprecated-dependency-configuration']
+
+            repositories {
+                mavenCentral()
+            }
+            
+            dependencies {
+                compile('example:foo:1.0.0') {
+                    exclude module: 'spring-boot-starter-tomcat'
+                }
+            }
+        """
+        BuildFiles buildFiles = new BuildFiles([buildFile])
+        GradleViolation mockViolation = Mock(GradleViolation)
+        MethodCallExpression mockMethodCallExpression = Mock(MethodCallExpression)
+
+        when:
+        DependencyViolationUtil.replaceDependencyConfiguration(mockViolation, mockMethodCallExpression, 'implementation')
+
+        then:
+        1 * mockViolation.getFiles() >> buildFiles
+        1 * mockMethodCallExpression.getLineNumber() >> 13
+        1 * mockMethodCallExpression.getLastLineNumber() >> 16
+        1 * mockViolation.replaceWith(mockMethodCallExpression, "dependencies {\n                implementation(\'example:foo:1.0.0\') {\n                    exclude module: \'spring-boot-starter-tomcat\'\n                }")
+        1 * mockMethodCallExpression.getMethodAsString() >> 'compile'
+    }
+
+
+}

--- a/src/test/groovy/com/netflix/nebula/lint/rule/dependency/DependencyViolationUtilSpec.groovy
+++ b/src/test/groovy/com/netflix/nebula/lint/rule/dependency/DependencyViolationUtilSpec.groovy
@@ -70,5 +70,16 @@ class DependencyViolationUtilSpec extends Specification {
         1 * mockMethodCallExpression.getMethodAsString() >> 'compile'
     }
 
+    def 'replaces project dependency configuration'() {
+        setup:
+        GradleViolation mockViolation = Mock(GradleViolation)
+        MethodCallExpression mockMethodCallExpression = Mock(MethodCallExpression)
+
+        when:
+        DependencyViolationUtil.replaceProjectDependencyConfiguration(mockViolation, mockMethodCallExpression, "implementation", ":sub1")
+
+        then:
+        1 * mockViolation.replaceWith(mockMethodCallExpression, "implementation project(':sub1')")
+    }
 
 }

--- a/src/test/groovy/com/netflix/nebula/lint/rule/dependency/DeprecatedDependencyConfigurationRuleSpec.groovy
+++ b/src/test/groovy/com/netflix/nebula/lint/rule/dependency/DeprecatedDependencyConfigurationRuleSpec.groovy
@@ -103,8 +103,8 @@ class DeprecatedDependencyConfigurationRuleSpec extends TestKitSpecification {
         def result = runTasksSuccessfully('fixGradleLint', '--warning-mode=none')
 
         then:
-        def buildGradle = new File(projectDir, 'sub1/build.gradle')
-        buildGradle.text.trim() == """
+        def sub1BuildGradle = new File(projectDir, 'sub1/build.gradle')
+        sub1BuildGradle.text.trim() == """
 repositories {
     mavenCentral()
 }

--- a/src/test/groovy/com/netflix/nebula/lint/rule/dependency/DeprecatedDependencyConfigurationRuleSpec.groovy
+++ b/src/test/groovy/com/netflix/nebula/lint/rule/dependency/DeprecatedDependencyConfigurationRuleSpec.groovy
@@ -55,6 +55,75 @@ class DeprecatedDependencyConfigurationRuleSpec extends TestKitSpecification {
         "runtime"     | "runtimeOnly"
     }
 
+    def 'Replaces deprecated configurations - multi project - project dependency - #configuration for #replacementConfiguration'() {
+        def sub1 = addSubproject('sub1', """
+            repositories {
+                mavenCentral()
+            }
+            
+            dependencies {
+                $configuration 'com.google.guava:guava:19.0'
+                $configuration project(':sub2')
+            }
+
+            def x = "test"
+            """.stripIndent())
+
+        createJavaSourceFile(sub1, 'public class Sub1 {}')
+
+        def sub2 = addSubproject('sub2', """            
+            repositories {
+                mavenCentral()
+            }
+            
+            dependencies {
+                $configuration 'com.google.guava:guava:19.0'
+            }
+            """.stripIndent())
+
+        createJavaSourceFile(sub2, 'public class Sub2 {}')
+
+        buildFile << """
+            plugins {
+                id 'nebula.lint'
+            }
+            
+            subprojects {
+                apply plugin: 'java'
+                apply plugin: 'nebula.lint'
+            }
+              
+            allprojects {
+                  gradleLint.rules = ['deprecated-dependency-configuration']
+            }
+
+        """
+
+        when:
+        def result = runTasksSuccessfully('fixGradleLint', '--warning-mode=none')
+
+        then:
+        def buildGradle = new File(projectDir, 'sub1/build.gradle')
+        buildGradle.text.trim() == """
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    $replacementConfiguration 'com.google.guava:guava:19.0'
+    $replacementConfiguration project(':sub2')
+}
+
+def x = "test"
+        """.trim()
+
+        where:
+        configuration | replacementConfiguration
+        "compile"     | "implementation"
+        "testCompile" | "testImplementation"
+        "runtime"     | "runtimeOnly"
+    }
+
 
     def 'Replaces deprecated configuration - latest release - #configuration for #replacementConfiguration'() {
         buildFile << """

--- a/src/test/groovy/com/netflix/nebula/lint/rule/dependency/DeprecatedDependencyConfigurationRuleSpec.groovy
+++ b/src/test/groovy/com/netflix/nebula/lint/rule/dependency/DeprecatedDependencyConfigurationRuleSpec.groovy
@@ -1,0 +1,203 @@
+package com.netflix.nebula.lint.rule.dependency
+
+import com.netflix.nebula.lint.TestKitSpecification
+import spock.lang.Subject
+import spock.lang.Unroll
+
+@Unroll
+@Subject(DeprecatedDependencyConfigurationRule)
+class DeprecatedDependencyConfigurationRuleSpec extends TestKitSpecification {
+
+    def 'Replaces deprecated configurations - #configuration for #replacementConfiguration'() {
+        buildFile << """
+            plugins {
+                id 'nebula.lint'
+                id 'java'
+            }
+
+            gradleLint.rules = ['deprecated-dependency-configuration']
+
+            repositories {
+                mavenCentral()
+            }
+            
+            dependencies {
+                $configuration 'com.google.guava:guava:19.0'
+            }
+        """
+
+        when:
+        def result = runTasksSuccessfully('fixGradleLint', '--warning-mode=none')
+
+        then:
+        def buildGradle = new File(projectDir, 'build.gradle')
+        buildGradle.text.trim() == """
+            plugins {
+                id 'nebula.lint'
+                id 'java'
+            }
+
+            gradleLint.rules = ['deprecated-dependency-configuration']
+
+            repositories {
+                mavenCentral()
+            }
+            
+            dependencies {
+                $replacementConfiguration 'com.google.guava:guava:19.0'
+            }
+        """.trim()
+
+        where:
+        configuration | replacementConfiguration
+        "compile"     | "implementation"
+        "testCompile" | "testImplementation"
+        "runtime"     | "runtimeOnly"
+    }
+
+
+    def 'replace server dependency configuration - latest release - #configuration for #replacementConfiguration'() {
+        buildFile << """
+            plugins {
+                id 'nebula.lint'
+                id 'java'
+            }
+
+            gradleLint.rules = ['deprecated-dependency-configuration']
+
+            repositories {
+                mavenCentral()
+            }
+            
+            dependencies {
+                $configuration 'org.apache.tomcat:tomcat-catalina:latest.release'
+            }
+        """
+
+        when:
+        def result = runTasksSuccessfully('fixGradleLint', '--warning-mode=none')
+
+        then:
+        def buildGradle = new File(projectDir, 'build.gradle')
+        buildGradle.text.trim() == """
+            plugins {
+                id 'nebula.lint'
+                id 'java'
+            }
+
+            gradleLint.rules = ['deprecated-dependency-configuration']
+
+            repositories {
+                mavenCentral()
+            }
+            
+            dependencies {
+                $replacementConfiguration 'org.apache.tomcat:tomcat-catalina:latest.release'
+            }
+        """.trim()
+
+        where:
+        configuration | replacementConfiguration
+        "compile"     | "implementation"
+        "testCompile" | "testImplementation"
+        "runtime"     | "runtimeOnly"
+    }
+
+    def 'replace server dependency configuration - dynamic version  - #configuration for #replacementConfiguration'() {
+        buildFile << """
+            plugins {
+                id 'nebula.lint'
+                id 'java'
+            }
+
+            gradleLint.rules = ['deprecated-dependency-configuration']
+
+            repositories {
+                mavenCentral()
+            }
+            
+            dependencies {
+                $configuration 'org.apache.tomcat:tomcat-catalina:7.+'
+            }
+        """
+
+        when:
+        def result = runTasksSuccessfully('fixGradleLint', '--warning-mode=none')
+
+        then:
+        def buildGradle = new File(projectDir, 'build.gradle')
+        buildGradle.text.trim() == """
+            plugins {
+                id 'nebula.lint'
+                id 'java'
+            }
+
+            gradleLint.rules = ['deprecated-dependency-configuration']
+
+            repositories {
+                mavenCentral()
+            }
+            
+            dependencies {
+                $replacementConfiguration 'org.apache.tomcat:tomcat-catalina:7.+'
+            }
+        """.trim()
+
+        where:
+        configuration | replacementConfiguration
+        "compile"     | "implementation"
+        "testCompile" | "testImplementation"
+        "runtime"     | "runtimeOnly"
+    }
+
+    def 'replace server dependency configuration - with excludes - #configuration for #replacementConfiguration'() {
+        buildFile << """
+            plugins {
+                id 'nebula.lint'
+                id 'java'
+            }
+
+            gradleLint.rules = ['deprecated-dependency-configuration']
+
+            repositories {
+                mavenCentral()
+            }
+            
+            dependencies {
+                $configuration('org.apache.tomcat:tomcat-catalina:latest.release') {
+                    exclude module: "spring-boot-starter-tomcat"
+                }
+            }
+        """
+
+        when:
+        def result = runTasksSuccessfully('fixGradleLint', '--warning-mode=none')
+
+        then:
+        def buildGradle = new File(projectDir, 'build.gradle')
+        buildGradle.text.trim() == """
+            plugins {
+                id 'nebula.lint'
+                id 'java'
+            }
+
+            gradleLint.rules = ['deprecated-dependency-configuration']
+
+            repositories {
+                mavenCentral()
+            }
+            
+            dependencies {
+                $replacementConfiguration('org.apache.tomcat:tomcat-catalina:latest.release') {
+                    exclude module: "spring-boot-starter-tomcat"
+                }
+            }
+        """.trim()
+
+        where:
+        configuration | replacementConfiguration
+        "compile"     | "implementation"
+        "testCompile" | "testImplementation"
+        "runtime"     | "runtimeOnly"
+    }
+}

--- a/src/test/groovy/com/netflix/nebula/lint/rule/dependency/DeprecatedDependencyConfigurationRuleSpec.groovy
+++ b/src/test/groovy/com/netflix/nebula/lint/rule/dependency/DeprecatedDependencyConfigurationRuleSpec.groovy
@@ -56,7 +56,7 @@ class DeprecatedDependencyConfigurationRuleSpec extends TestKitSpecification {
     }
 
 
-    def 'replace server dependency configuration - latest release - #configuration for #replacementConfiguration'() {
+    def 'Replaces deprecated configuration - latest release - #configuration for #replacementConfiguration'() {
         buildFile << """
             plugins {
                 id 'nebula.lint'
@@ -103,7 +103,7 @@ class DeprecatedDependencyConfigurationRuleSpec extends TestKitSpecification {
         "runtime"     | "runtimeOnly"
     }
 
-    def 'replace server dependency configuration - dynamic version  - #configuration for #replacementConfiguration'() {
+    def 'Replaces deprecated configuration - dynamic version  - #configuration for #replacementConfiguration'() {
         buildFile << """
             plugins {
                 id 'nebula.lint'
@@ -150,7 +150,7 @@ class DeprecatedDependencyConfigurationRuleSpec extends TestKitSpecification {
         "runtime"     | "runtimeOnly"
     }
 
-    def 'replace server dependency configuration - with excludes - #configuration for #replacementConfiguration'() {
+    def 'Replaces deprecated dconfiguration - with excludes - #configuration for #replacementConfiguration'() {
         buildFile << """
             plugins {
                 id 'nebula.lint'

--- a/src/test/groovy/com/netflix/nebula/lint/rule/dependency/OldGradleDeprecatedDependencyConfigurationRuleSpec.groovy
+++ b/src/test/groovy/com/netflix/nebula/lint/rule/dependency/OldGradleDeprecatedDependencyConfigurationRuleSpec.groovy
@@ -106,8 +106,8 @@ class OldGradleDeprecatedDependencyConfigurationRuleSpec extends TestKitSpecific
         def result = runTasksSuccessfully('fixGradleLint', '--warning-mode=none')
 
         then:
-        def buildGradle = new File(projectDir, 'sub1/build.gradle')
-        buildGradle.text.trim() == """
+        def sub1BuildGradle = new File(projectDir, 'sub1/build.gradle')
+        sub1BuildGradle.text.trim() == """
 repositories {
     mavenCentral()
 }

--- a/src/test/groovy/com/netflix/nebula/lint/rule/dependency/OldGradleDeprecatedDependencyConfigurationRuleSpec.groovy
+++ b/src/test/groovy/com/netflix/nebula/lint/rule/dependency/OldGradleDeprecatedDependencyConfigurationRuleSpec.groovy
@@ -1,0 +1,200 @@
+package com.netflix.nebula.lint.rule.dependency
+
+import com.netflix.nebula.lint.TestKitSpecification
+import spock.lang.Subject
+import spock.lang.Unroll
+
+@Unroll
+@Subject(DeprecatedDependencyConfigurationRule)
+class OldGradleDeprecatedDependencyConfigurationRuleSpec extends TestKitSpecification {
+
+    //Should not replace with gradle < 4.7
+    def setup() {
+        gradleVersion = "4.6"
+    }
+
+    def 'Replaces deprecated configurations - #configuration for #replacementConfiguration'() {
+        buildFile << """
+            plugins {
+                id 'nebula.lint'
+                id 'java'
+            }
+
+            gradleLint.rules = ['deprecated-dependency-configuration']
+
+            repositories {
+                mavenCentral()
+            }
+            
+            dependencies {
+                $configuration 'com.google.guava:guava:19.0'
+            }
+        """
+
+        when:
+        def result = runTasksSuccessfully('fixGradleLint', '--warning-mode=none')
+
+        then:
+        def buildGradle = new File(projectDir, 'build.gradle')
+        buildGradle.text.trim() == """
+            plugins {
+                id 'nebula.lint'
+                id 'java'
+            }
+
+            gradleLint.rules = ['deprecated-dependency-configuration']
+
+            repositories {
+                mavenCentral()
+            }
+            
+            dependencies {
+                $configuration 'com.google.guava:guava:19.0'
+            }
+        """.trim()
+
+        where:
+        configuration << ["compile", "testCompile", "runtime"]
+
+    }
+
+
+    def 'replace server dependency configuration - latest release - #configuration for #replacementConfiguration'() {
+        buildFile << """
+            plugins {
+                id 'nebula.lint'
+                id 'java'
+            }
+
+            gradleLint.rules = ['deprecated-dependency-configuration']
+
+            repositories {
+                mavenCentral()
+            }
+            
+            dependencies {
+                $configuration 'org.apache.tomcat:tomcat-catalina:latest.release'
+            }
+        """
+
+        when:
+        def result = runTasksSuccessfully('fixGradleLint', '--warning-mode=none')
+
+        then:
+        def buildGradle = new File(projectDir, 'build.gradle')
+        buildGradle.text.trim() == """
+            plugins {
+                id 'nebula.lint'
+                id 'java'
+            }
+
+            gradleLint.rules = ['deprecated-dependency-configuration']
+
+            repositories {
+                mavenCentral()
+            }
+            
+            dependencies {
+                $configuration 'org.apache.tomcat:tomcat-catalina:latest.release'
+            }
+        """.trim()
+
+        where:
+        configuration << ["compile", "testCompile", "runtime"]
+
+    }
+
+    def 'replace server dependency configuration - dynamic version  - #configuration for #replacementConfiguration'() {
+        buildFile << """
+            plugins {
+                id 'nebula.lint'
+                id 'java'
+            }
+
+            gradleLint.rules = ['deprecated-dependency-configuration']
+
+            repositories {
+                mavenCentral()
+            }
+            
+            dependencies {
+                $configuration 'org.apache.tomcat:tomcat-catalina:7.+'
+            }
+        """
+
+        when:
+        def result = runTasksSuccessfully('fixGradleLint', '--warning-mode=none')
+
+        then:
+        def buildGradle = new File(projectDir, 'build.gradle')
+        buildGradle.text.trim() == """
+            plugins {
+                id 'nebula.lint'
+                id 'java'
+            }
+
+            gradleLint.rules = ['deprecated-dependency-configuration']
+
+            repositories {
+                mavenCentral()
+            }
+            
+            dependencies {
+                $configuration 'org.apache.tomcat:tomcat-catalina:7.+'
+            }
+        """.trim()
+
+        where:
+        configuration << ["compile", "testCompile", "runtime"]
+
+    }
+
+    def 'replace server dependency configuration - with excludes - #configuration for #replacementConfiguration'() {
+        buildFile << """
+            plugins {
+                id 'nebula.lint'
+                id 'java'
+            }
+
+            gradleLint.rules = ['deprecated-dependency-configuration']
+
+            repositories {
+                mavenCentral()
+            }
+            
+            dependencies {
+                $configuration('org.apache.tomcat:tomcat-catalina:latest.release') {
+                    exclude module: "spring-boot-starter-tomcat"
+                }
+            }
+        """
+
+        when:
+        def result = runTasksSuccessfully('fixGradleLint', '--warning-mode=none')
+
+        then:
+        def buildGradle = new File(projectDir, 'build.gradle')
+        buildGradle.text.trim() == """
+            plugins {
+                id 'nebula.lint'
+                id 'java'
+            }
+
+            gradleLint.rules = ['deprecated-dependency-configuration']
+
+            repositories {
+                mavenCentral()
+            }
+            
+            dependencies {
+                $configuration('org.apache.tomcat:tomcat-catalina:latest.release') {
+                    exclude module: "spring-boot-starter-tomcat"
+                }
+            }
+        """.trim()
+
+        where:
+        configuration << ["compile", "testCompile", "runtime"]
+
+    }
+}

--- a/src/test/groovy/com/netflix/nebula/lint/rule/dependency/OldGradleDeprecatedDependencyConfigurationRuleSpec.groovy
+++ b/src/test/groovy/com/netflix/nebula/lint/rule/dependency/OldGradleDeprecatedDependencyConfigurationRuleSpec.groovy
@@ -59,7 +59,7 @@ class OldGradleDeprecatedDependencyConfigurationRuleSpec extends TestKitSpecific
     }
 
 
-    def 'replace server dependency configuration - latest release - #configuration for #replacementConfiguration'() {
+    def 'Replaces deprecated configuration - latest release - #configuration for #replacementConfiguration'() {
         buildFile << """
             plugins {
                 id 'nebula.lint'
@@ -104,7 +104,7 @@ class OldGradleDeprecatedDependencyConfigurationRuleSpec extends TestKitSpecific
 
     }
 
-    def 'replace server dependency configuration - dynamic version  - #configuration for #replacementConfiguration'() {
+    def 'Replaces deprecated configuration  - dynamic version  - #configuration for #replacementConfiguration'() {
         buildFile << """
             plugins {
                 id 'nebula.lint'
@@ -149,7 +149,7 @@ class OldGradleDeprecatedDependencyConfigurationRuleSpec extends TestKitSpecific
 
     }
 
-    def 'replace server dependency configuration - with excludes - #configuration for #replacementConfiguration'() {
+    def 'Replaces deprecated configuration  - with excludes - #configuration for #replacementConfiguration'() {
         buildFile << """
             plugins {
                 id 'nebula.lint'


### PR DESCRIPTION
This is work for https://github.com/nebula-plugins/gradle-lint-plugin/issues/203 

Several dependencies configurations have been deprecated but gradle-lint-plugin makes recommendations to use those.

While it could be possible to modify existing rules to use the non-deprecated configurations, it would break backwards compatibility since this was introduced in gradle 4.7 so it isn't that old.

I propose to introduce this rule that applies for gradle 4.7 which would replace configurations and in the future we can revisit this. Perhaps for Gradle 6 it would make sense to stop supporting Gradle < 4.5