### PR TITLE
Limit dependencies by placing gradle-info-plugin to compileOnly.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,7 @@ configurations {
 }
 
 dependencies {
+    compileOnly 'com.netflix.nebula:gradle-info-plugin:latest.release'
     compile 'com.netflix.nebula:nebula-gradle-interop:latest.release'
     compile 'org.apache.maven:maven-model-builder:3.+'
     plugin  'com.google.guava:guava:19.0'
@@ -45,7 +46,6 @@ dependencies {
     plugin('org.codenarc:CodeNarc:0.25.2') {
         transitive = false
     }
-    plugin 'com.netflix.nebula:gradle-info-plugin:latest.release'
     plugin 'commons-lang:commons-lang:2.6'
 
     plugin ('org.eclipse.jgit:org.eclipse.jgit:5.0.1.201806211838-r') {
@@ -67,6 +67,7 @@ dependencies {
     }
     testCompile 'org.ow2.asm:asm-util:5.2'
     testCompile 'joda-time:joda-time:latest.release'
+    testCompile 'com.netflix.nebula:gradle-info-plugin:latest.release'
 }
 
 pluginBundle {

--- a/dependencies.lock
+++ b/dependencies.lock
@@ -4,10 +4,6 @@
             "locked": "19.0",
             "requested": "19.0"
         },
-        "com.netflix.nebula:gradle-info-plugin": {
-            "locked": "4.0.3",
-            "requested": "latest.release"
-        },
         "com.netflix.nebula:nebula-gradle-interop": {
             "locked": "1.0.2",
             "requested": "latest.release"
@@ -61,10 +57,6 @@
         "com.google.guava:guava": {
             "locked": "19.0",
             "requested": "19.0"
-        },
-        "com.netflix.nebula:gradle-info-plugin": {
-            "locked": "4.0.3",
-            "requested": "latest.release"
         },
         "com.netflix.nebula:nebula-gradle-interop": {
             "locked": "1.0.2",
@@ -173,14 +165,22 @@
             "requested": "1.0-groovy-2.4"
         }
     },
+    "compileOnly": {
+        "com.netflix.nebula:gradle-info-plugin": {
+            "locked": "4.0.3",
+            "requested": "latest.release"
+        }
+    },
+    "compileOnlyDependenciesMetadata": {
+        "com.netflix.nebula:gradle-info-plugin": {
+            "locked": "4.0.3",
+            "requested": "latest.release"
+        }
+    },
     "default": {
         "com.google.guava:guava": {
             "locked": "19.0",
             "requested": "19.0"
-        },
-        "com.netflix.nebula:gradle-info-plugin": {
-            "locked": "4.0.3",
-            "requested": "latest.release"
         },
         "com.netflix.nebula:nebula-gradle-interop": {
             "locked": "1.0.2",
@@ -235,10 +235,6 @@
         "com.google.guava:guava": {
             "locked": "19.0",
             "requested": "19.0"
-        },
-        "com.netflix.nebula:gradle-info-plugin": {
-            "locked": "4.0.3",
-            "requested": "latest.release"
         },
         "com.netflix.nebula:nebula-gradle-interop": {
             "locked": "1.0.2",
@@ -711,10 +707,6 @@
             "locked": "19.0",
             "requested": "19.0"
         },
-        "com.netflix.nebula:gradle-info-plugin": {
-            "locked": "4.0.3",
-            "requested": "latest.release"
-        },
         "com.netflix.nebula:nebula-test": {
             "locked": "7.1.0",
             "requested": "latest.release"
@@ -756,10 +748,6 @@
         "com.google.guava:guava": {
             "locked": "19.0",
             "requested": "19.0"
-        },
-        "com.netflix.nebula:gradle-info-plugin": {
-            "locked": "4.0.3",
-            "requested": "latest.release"
         },
         "com.netflix.nebula:nebula-gradle-interop": {
             "locked": "1.0.2",
@@ -814,10 +802,6 @@
         "com.google.guava:guava": {
             "locked": "19.0",
             "requested": "19.0"
-        },
-        "com.netflix.nebula:gradle-info-plugin": {
-            "locked": "4.0.3",
-            "requested": "latest.release"
         },
         "com.netflix.nebula:nebula-gradle-interop": {
             "locked": "1.0.2",

--- a/src/main/groovy/com/netflix/nebula/lint/GradleLintInfoBrokerAction.groovy
+++ b/src/main/groovy/com/netflix/nebula/lint/GradleLintInfoBrokerAction.groovy
@@ -1,7 +1,6 @@
 package com.netflix.nebula.lint
 
 import groovy.transform.Canonical
-import nebula.plugin.info.InfoBrokerPlugin
 import org.gradle.api.Project
 
 @Canonical
@@ -10,7 +9,7 @@ class GradleLintInfoBrokerAction extends GradleLintViolationAction {
 
     @Override
     void lintFinished(Collection<GradleViolation> violations) {
-        project.getPlugins().withType(InfoBrokerPlugin) {
+        project.getPlugins().withId('nebula.info-broker') {
             def reportItems = violations.collect { buildReportItem(it) }
             it.addReport('gradleLintViolations', reportItems)
         }
@@ -18,7 +17,7 @@ class GradleLintInfoBrokerAction extends GradleLintViolationAction {
 
     @Override
     void lintFixesApplied(Collection<GradleViolation> violations) {
-        project.getPlugins().withType(InfoBrokerPlugin) {
+        project.getPlugins().withId('nebula.info-broker') {
             def reportItems = violations.findAll { !it.fixes.any { it.reasonForNotFixing } }
                     .collect { buildReportItem(it) }
             it.addReport('fixedGradleLintViolations', reportItems)


### PR DESCRIPTION
Lint is widely consumed in our ecosystem and it brings jgit dependencies which then conflicts with other plugins. It is not necessary for lint to do that.