### PR TITLE
Enhance DependencyService to expose method level references

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,7 +46,8 @@ dependencies {
     compile 'org.apache.maven:maven-model-builder:3.+'
     plugin  'com.google.guava:guava:19.0'
 
-    plugin 'org.ow2.asm:asm:7.0'
+    plugin 'org.ow2.asm:asm:7.+'
+    plugin 'org.ow2.asm:asm-commons:7.+'
     plugin('org.codenarc:CodeNarc:0.25.2') {
         transitive = false
     }
@@ -110,12 +111,14 @@ shadowJar {
         include(dependency('commons-lang:commons-lang'))
         include(dependency('org.codenarc:CodeNarc'))
         include(dependency('org.ow2.asm:asm'))
+        include(dependency('org.ow2.asm:asm-commons'))
     }
     relocate 'org.eclipse.jdt', 'com.netflix.nebula.lint.jdt'
     relocate 'org.eclipse.jgit', 'com.netflix.nebula.lint.jgit'
     relocate 'org.apache.commons.lang', 'com.netflix.nebula.lint.commons.lang'
     relocate 'org.codenarc', 'com.netflix.nebula.lint.org.codenarc'
     relocate 'org.objectweb.asm', 'com.netflix.nebula.lint.org.objectweb.asm'
+    relocate 'org.objectweb.asm.commons', 'com.netflix.nebula.lint.org.objectweb.asm.commons'
 
     // powerassert is packed inside codenarc without relocation for some reason
     relocate 'org.codehaus.groovy.transform.powerassert', 'com.netflix.nebula.lint.org.codehaus.groovy.transform.powerassert'

--- a/dependencies.lock
+++ b/dependencies.lock
@@ -5,11 +5,11 @@
             "requested": "19.0"
         },
         "com.netflix.nebula:nebula-gradle-interop": {
-            "locked": "1.0.2",
+            "locked": "1.0.3",
             "requested": "latest.release"
         },
         "com.netflix.nebula:nebula-test": {
-            "locked": "7.1.7",
+            "locked": "7.1.8",
             "requested": "latest.release"
         },
         "commons-lang:commons-lang": {
@@ -41,12 +41,16 @@
             "requested": "5.0.1.201806211838-r"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk7": {
-            "locked": "1.3.0",
+            "locked": "1.3.11",
             "requested": "1.3.0"
         },
         "org.ow2.asm:asm": {
-            "locked": "7.0",
-            "requested": "7.0"
+            "locked": "7.1",
+            "requested": "7.+"
+        },
+        "org.ow2.asm:asm-commons": {
+            "locked": "7.1",
+            "requested": "7.+"
         },
         "org.spockframework:spock-core": {
             "locked": "1.0-groovy-2.4",
@@ -59,11 +63,11 @@
             "requested": "19.0"
         },
         "com.netflix.nebula:nebula-gradle-interop": {
-            "locked": "1.0.2",
+            "locked": "1.0.3",
             "requested": "latest.release"
         },
         "com.netflix.nebula:nebula-test": {
-            "locked": "7.1.7",
+            "locked": "7.1.8",
             "requested": "latest.release"
         },
         "commons-lang:commons-lang": {
@@ -95,12 +99,16 @@
             "requested": "5.0.1.201806211838-r"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk7": {
-            "locked": "1.3.0",
+            "locked": "1.3.11",
             "requested": "1.3.0"
         },
         "org.ow2.asm:asm": {
-            "locked": "7.0",
-            "requested": "7.0"
+            "locked": "7.1",
+            "requested": "7.+"
+        },
+        "org.ow2.asm:asm-commons": {
+            "locked": "7.1",
+            "requested": "7.+"
         },
         "org.spockframework:spock-core": {
             "locked": "1.0-groovy-2.4",
@@ -113,15 +121,15 @@
             "requested": "19.0"
         },
         "com.netflix.nebula:gradle-info-plugin": {
-            "locked": "4.0.3",
+            "locked": "5.0.0",
             "requested": "latest.release"
         },
         "com.netflix.nebula:nebula-gradle-interop": {
-            "locked": "1.0.2",
+            "locked": "1.0.3",
             "requested": "latest.release"
         },
         "com.netflix.nebula:nebula-test": {
-            "locked": "7.1.7",
+            "locked": "7.1.8",
             "requested": "latest.release"
         },
         "commons-lang:commons-lang": {
@@ -153,12 +161,16 @@
             "requested": "5.0.1.201806211838-r"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk7": {
-            "locked": "1.3.0",
+            "locked": "1.3.11",
             "requested": "1.3.0"
         },
         "org.ow2.asm:asm": {
-            "locked": "7.0",
-            "requested": "7.0"
+            "locked": "7.1",
+            "requested": "7.+"
+        },
+        "org.ow2.asm:asm-commons": {
+            "locked": "7.1",
+            "requested": "7.+"
         },
         "org.spockframework:spock-core": {
             "locked": "1.0-groovy-2.4",
@@ -167,13 +179,13 @@
     },
     "compileOnly": {
         "com.netflix.nebula:gradle-info-plugin": {
-            "locked": "4.0.3",
+            "locked": "5.0.0",
             "requested": "latest.release"
         }
     },
     "compileOnlyDependenciesMetadata": {
         "com.netflix.nebula:gradle-info-plugin": {
-            "locked": "4.0.3",
+            "locked": "5.0.0",
             "requested": "latest.release"
         }
     },
@@ -183,11 +195,11 @@
             "requested": "19.0"
         },
         "com.netflix.nebula:nebula-gradle-interop": {
-            "locked": "1.0.2",
+            "locked": "1.0.3",
             "requested": "latest.release"
         },
         "com.netflix.nebula:nebula-test": {
-            "locked": "7.1.7",
+            "locked": "7.1.8",
             "requested": "latest.release"
         },
         "commons-lang:commons-lang": {
@@ -219,12 +231,16 @@
             "requested": "5.0.1.201806211838-r"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk7": {
-            "locked": "1.3.0",
+            "locked": "1.3.11",
             "requested": "1.3.0"
         },
         "org.ow2.asm:asm": {
-            "locked": "7.0",
-            "requested": "7.0"
+            "locked": "7.1",
+            "requested": "7.+"
+        },
+        "org.ow2.asm:asm-commons": {
+            "locked": "7.1",
+            "requested": "7.+"
         },
         "org.spockframework:spock-core": {
             "locked": "1.0-groovy-2.4",
@@ -237,11 +253,11 @@
             "requested": "19.0"
         },
         "com.netflix.nebula:nebula-gradle-interop": {
-            "locked": "1.0.2",
+            "locked": "1.0.3",
             "requested": "latest.release"
         },
         "com.netflix.nebula:nebula-test": {
-            "locked": "7.1.7",
+            "locked": "7.1.8",
             "requested": "latest.release"
         },
         "commons-lang:commons-lang": {
@@ -273,12 +289,16 @@
             "requested": "5.0.1.201806211838-r"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk7": {
-            "locked": "1.3.0",
+            "locked": "1.3.11",
             "requested": "1.3.0"
         },
         "org.ow2.asm:asm": {
-            "locked": "7.0",
-            "requested": "7.0"
+            "locked": "7.1",
+            "requested": "7.+"
+        },
+        "org.ow2.asm:asm-commons": {
+            "locked": "7.1",
+            "requested": "7.+"
         },
         "org.spockframework:spock-core": {
             "locked": "1.0-groovy-2.4",
@@ -291,15 +311,15 @@
             "requested": "19.0"
         },
         "com.netflix.nebula:gradle-info-plugin": {
-            "locked": "4.0.3",
+            "locked": "5.0.0",
             "requested": "latest.release"
         },
         "com.netflix.nebula:nebula-gradle-interop": {
-            "locked": "1.0.2",
+            "locked": "1.0.3",
             "requested": "latest.release"
         },
         "com.netflix.nebula:nebula-test": {
-            "locked": "7.1.7",
+            "locked": "7.1.8",
             "requested": "latest.release"
         },
         "commons-lang:commons-lang": {
@@ -335,12 +355,16 @@
             "requested": "5.0.1.201806211838-r"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk7": {
-            "locked": "1.3.0",
+            "locked": "1.3.11",
             "requested": "1.3.0"
         },
         "org.ow2.asm:asm": {
-            "locked": "7.0",
-            "requested": "7.0"
+            "locked": "7.1",
+            "requested": "7.+"
+        },
+        "org.ow2.asm:asm-commons": {
+            "locked": "7.1",
+            "requested": "7.+"
         },
         "org.ow2.asm:asm-util": {
             "locked": "5.2",
@@ -357,15 +381,15 @@
             "requested": "19.0"
         },
         "com.netflix.nebula:gradle-info-plugin": {
-            "locked": "4.0.3",
+            "locked": "5.0.0",
             "requested": "latest.release"
         },
         "com.netflix.nebula:nebula-gradle-interop": {
-            "locked": "1.0.2",
+            "locked": "1.0.3",
             "requested": "latest.release"
         },
         "com.netflix.nebula:nebula-test": {
-            "locked": "7.1.7",
+            "locked": "7.1.8",
             "requested": "latest.release"
         },
         "commons-lang:commons-lang": {
@@ -401,12 +425,16 @@
             "requested": "5.0.1.201806211838-r"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk7": {
-            "locked": "1.3.0",
+            "locked": "1.3.11",
             "requested": "1.3.0"
         },
         "org.ow2.asm:asm": {
-            "locked": "7.0",
-            "requested": "7.0"
+            "locked": "7.1",
+            "requested": "7.+"
+        },
+        "org.ow2.asm:asm-commons": {
+            "locked": "7.1",
+            "requested": "7.+"
         },
         "org.ow2.asm:asm-util": {
             "locked": "5.2",
@@ -423,15 +451,15 @@
             "requested": "19.0"
         },
         "com.netflix.nebula:gradle-info-plugin": {
-            "locked": "4.0.3",
+            "locked": "5.0.0",
             "requested": "latest.release"
         },
         "com.netflix.nebula:nebula-gradle-interop": {
-            "locked": "1.0.2",
+            "locked": "1.0.3",
             "requested": "latest.release"
         },
         "com.netflix.nebula:nebula-test": {
-            "locked": "7.1.7",
+            "locked": "7.1.8",
             "requested": "latest.release"
         },
         "commons-lang:commons-lang": {
@@ -467,12 +495,16 @@
             "requested": "5.0.1.201806211838-r"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk7": {
-            "locked": "1.3.0",
+            "locked": "1.3.11",
             "requested": "1.3.0"
         },
         "org.ow2.asm:asm": {
-            "locked": "7.0",
-            "requested": "7.0"
+            "locked": "7.1",
+            "requested": "7.+"
+        },
+        "org.ow2.asm:asm-commons": {
+            "locked": "7.1",
+            "requested": "7.+"
         },
         "org.ow2.asm:asm-util": {
             "locked": "5.2",
@@ -489,15 +521,15 @@
             "requested": "19.0"
         },
         "com.netflix.nebula:gradle-info-plugin": {
-            "locked": "4.0.3",
+            "locked": "5.0.0",
             "requested": "latest.release"
         },
         "com.netflix.nebula:nebula-gradle-interop": {
-            "locked": "1.0.2",
+            "locked": "1.0.3",
             "requested": "latest.release"
         },
         "com.netflix.nebula:nebula-test": {
-            "locked": "7.1.7",
+            "locked": "7.1.8",
             "requested": "latest.release"
         },
         "commons-lang:commons-lang": {
@@ -533,12 +565,16 @@
             "requested": "5.0.1.201806211838-r"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk7": {
-            "locked": "1.3.0",
+            "locked": "1.3.11",
             "requested": "1.3.0"
         },
         "org.ow2.asm:asm": {
-            "locked": "7.0",
-            "requested": "7.0"
+            "locked": "7.1",
+            "requested": "7.+"
+        },
+        "org.ow2.asm:asm-commons": {
+            "locked": "7.1",
+            "requested": "7.+"
         },
         "org.ow2.asm:asm-util": {
             "locked": "5.2",
@@ -555,15 +591,15 @@
             "requested": "19.0"
         },
         "com.netflix.nebula:gradle-info-plugin": {
-            "locked": "4.0.3",
+            "locked": "5.0.0",
             "requested": "latest.release"
         },
         "com.netflix.nebula:nebula-gradle-interop": {
-            "locked": "1.0.2",
+            "locked": "1.0.3",
             "requested": "latest.release"
         },
         "com.netflix.nebula:nebula-test": {
-            "locked": "7.1.7",
+            "locked": "7.1.8",
             "requested": "latest.release"
         },
         "commons-lang:commons-lang": {
@@ -599,12 +635,16 @@
             "requested": "5.0.1.201806211838-r"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk7": {
-            "locked": "1.3.0",
+            "locked": "1.3.11",
             "requested": "1.3.0"
         },
         "org.ow2.asm:asm": {
-            "locked": "7.0",
-            "requested": "7.0"
+            "locked": "7.1",
+            "requested": "7.+"
+        },
+        "org.ow2.asm:asm-commons": {
+            "locked": "7.1",
+            "requested": "7.+"
         },
         "org.ow2.asm:asm-util": {
             "locked": "5.2",
@@ -621,15 +661,15 @@
             "requested": "19.0"
         },
         "com.netflix.nebula:gradle-info-plugin": {
-            "locked": "4.0.3",
+            "locked": "5.0.0",
             "requested": "latest.release"
         },
         "com.netflix.nebula:nebula-gradle-interop": {
-            "locked": "1.0.2",
+            "locked": "1.0.3",
             "requested": "latest.release"
         },
         "com.netflix.nebula:nebula-test": {
-            "locked": "7.1.7",
+            "locked": "7.1.8",
             "requested": "latest.release"
         },
         "commons-lang:commons-lang": {
@@ -665,12 +705,16 @@
             "requested": "5.0.1.201806211838-r"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk7": {
-            "locked": "1.3.0",
+            "locked": "1.3.11",
             "requested": "1.3.0"
         },
         "org.ow2.asm:asm": {
-            "locked": "7.0",
-            "requested": "7.0"
+            "locked": "7.1",
+            "requested": "7.+"
+        },
+        "org.ow2.asm:asm-commons": {
+            "locked": "7.1",
+            "requested": "7.+"
         },
         "org.ow2.asm:asm-util": {
             "locked": "5.2",
@@ -708,7 +752,7 @@
             "requested": "19.0"
         },
         "com.netflix.nebula:nebula-test": {
-            "locked": "7.1.7",
+            "locked": "7.1.8",
             "requested": "latest.release"
         },
         "commons-lang:commons-lang": {
@@ -736,8 +780,12 @@
             "requested": "5.0.1.201806211838-r"
         },
         "org.ow2.asm:asm": {
-            "locked": "7.0",
-            "requested": "7.0"
+            "locked": "7.1",
+            "requested": "7.+"
+        },
+        "org.ow2.asm:asm-commons": {
+            "locked": "7.1",
+            "requested": "7.+"
         },
         "org.spockframework:spock-core": {
             "locked": "1.0-groovy-2.4",
@@ -750,11 +798,11 @@
             "requested": "19.0"
         },
         "com.netflix.nebula:nebula-gradle-interop": {
-            "locked": "1.0.2",
+            "locked": "1.0.3",
             "requested": "latest.release"
         },
         "com.netflix.nebula:nebula-test": {
-            "locked": "7.1.7",
+            "locked": "7.1.8",
             "requested": "latest.release"
         },
         "commons-lang:commons-lang": {
@@ -786,12 +834,16 @@
             "requested": "5.0.1.201806211838-r"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk7": {
-            "locked": "1.3.0",
+            "locked": "1.3.11",
             "requested": "1.3.0"
         },
         "org.ow2.asm:asm": {
-            "locked": "7.0",
-            "requested": "7.0"
+            "locked": "7.1",
+            "requested": "7.+"
+        },
+        "org.ow2.asm:asm-commons": {
+            "locked": "7.1",
+            "requested": "7.+"
         },
         "org.spockframework:spock-core": {
             "locked": "1.0-groovy-2.4",
@@ -804,11 +856,11 @@
             "requested": "19.0"
         },
         "com.netflix.nebula:nebula-gradle-interop": {
-            "locked": "1.0.2",
+            "locked": "1.0.3",
             "requested": "latest.release"
         },
         "com.netflix.nebula:nebula-test": {
-            "locked": "7.1.7",
+            "locked": "7.1.8",
             "requested": "latest.release"
         },
         "commons-lang:commons-lang": {
@@ -840,12 +892,16 @@
             "requested": "5.0.1.201806211838-r"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk7": {
-            "locked": "1.3.0",
+            "locked": "1.3.11",
             "requested": "1.3.0"
         },
         "org.ow2.asm:asm": {
-            "locked": "7.0",
-            "requested": "7.0"
+            "locked": "7.1",
+            "requested": "7.+"
+        },
+        "org.ow2.asm:asm-commons": {
+            "locked": "7.1",
+            "requested": "7.+"
         },
         "org.spockframework:spock-core": {
             "locked": "1.0-groovy-2.4",
@@ -858,15 +914,15 @@
             "requested": "19.0"
         },
         "com.netflix.nebula:gradle-info-plugin": {
-            "locked": "4.0.3",
+            "locked": "5.0.0",
             "requested": "latest.release"
         },
         "com.netflix.nebula:nebula-gradle-interop": {
-            "locked": "1.0.2",
+            "locked": "1.0.3",
             "requested": "latest.release"
         },
         "com.netflix.nebula:nebula-test": {
-            "locked": "7.1.7",
+            "locked": "7.1.8",
             "requested": "latest.release"
         },
         "commons-lang:commons-lang": {
@@ -902,12 +958,16 @@
             "requested": "5.0.1.201806211838-r"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk7": {
-            "locked": "1.3.0",
+            "locked": "1.3.11",
             "requested": "1.3.0"
         },
         "org.ow2.asm:asm": {
-            "locked": "7.0",
-            "requested": "7.0"
+            "locked": "7.1",
+            "requested": "7.+"
+        },
+        "org.ow2.asm:asm-commons": {
+            "locked": "7.1",
+            "requested": "7.+"
         },
         "org.ow2.asm:asm-util": {
             "locked": "5.2",
@@ -924,15 +984,15 @@
             "requested": "19.0"
         },
         "com.netflix.nebula:gradle-info-plugin": {
-            "locked": "4.0.3",
+            "locked": "5.0.0",
             "requested": "latest.release"
         },
         "com.netflix.nebula:nebula-gradle-interop": {
-            "locked": "1.0.2",
+            "locked": "1.0.3",
             "requested": "latest.release"
         },
         "com.netflix.nebula:nebula-test": {
-            "locked": "7.1.7",
+            "locked": "7.1.8",
             "requested": "latest.release"
         },
         "commons-lang:commons-lang": {
@@ -968,12 +1028,16 @@
             "requested": "5.0.1.201806211838-r"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk7": {
-            "locked": "1.3.0",
+            "locked": "1.3.11",
             "requested": "1.3.0"
         },
         "org.ow2.asm:asm": {
-            "locked": "7.0",
-            "requested": "7.0"
+            "locked": "7.1",
+            "requested": "7.+"
+        },
+        "org.ow2.asm:asm-commons": {
+            "locked": "7.1",
+            "requested": "7.+"
         },
         "org.ow2.asm:asm-util": {
             "locked": "5.2",
@@ -990,15 +1054,15 @@
             "requested": "19.0"
         },
         "com.netflix.nebula:gradle-info-plugin": {
-            "locked": "4.0.3",
+            "locked": "5.0.0",
             "requested": "latest.release"
         },
         "com.netflix.nebula:nebula-gradle-interop": {
-            "locked": "1.0.2",
+            "locked": "1.0.3",
             "requested": "latest.release"
         },
         "com.netflix.nebula:nebula-test": {
-            "locked": "7.1.7",
+            "locked": "7.1.8",
             "requested": "latest.release"
         },
         "commons-lang:commons-lang": {
@@ -1034,12 +1098,16 @@
             "requested": "5.0.1.201806211838-r"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk7": {
-            "locked": "1.3.0",
+            "locked": "1.3.11",
             "requested": "1.3.0"
         },
         "org.ow2.asm:asm": {
-            "locked": "7.0",
-            "requested": "7.0"
+            "locked": "7.1",
+            "requested": "7.+"
+        },
+        "org.ow2.asm:asm-commons": {
+            "locked": "7.1",
+            "requested": "7.+"
         },
         "org.ow2.asm:asm-util": {
             "locked": "5.2",
@@ -1056,15 +1124,15 @@
             "requested": "19.0"
         },
         "com.netflix.nebula:gradle-info-plugin": {
-            "locked": "4.0.3",
+            "locked": "5.0.0",
             "requested": "latest.release"
         },
         "com.netflix.nebula:nebula-gradle-interop": {
-            "locked": "1.0.2",
+            "locked": "1.0.3",
             "requested": "latest.release"
         },
         "com.netflix.nebula:nebula-test": {
-            "locked": "7.1.7",
+            "locked": "7.1.8",
             "requested": "latest.release"
         },
         "commons-lang:commons-lang": {
@@ -1100,12 +1168,16 @@
             "requested": "5.0.1.201806211838-r"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk7": {
-            "locked": "1.3.0",
+            "locked": "1.3.11",
             "requested": "1.3.0"
         },
         "org.ow2.asm:asm": {
-            "locked": "7.0",
-            "requested": "7.0"
+            "locked": "7.1",
+            "requested": "7.+"
+        },
+        "org.ow2.asm:asm-commons": {
+            "locked": "7.1",
+            "requested": "7.+"
         },
         "org.ow2.asm:asm-util": {
             "locked": "5.2",
@@ -1122,15 +1194,15 @@
             "requested": "19.0"
         },
         "com.netflix.nebula:gradle-info-plugin": {
-            "locked": "4.0.3",
+            "locked": "5.0.0",
             "requested": "latest.release"
         },
         "com.netflix.nebula:nebula-gradle-interop": {
-            "locked": "1.0.2",
+            "locked": "1.0.3",
             "requested": "latest.release"
         },
         "com.netflix.nebula:nebula-test": {
-            "locked": "7.1.7",
+            "locked": "7.1.8",
             "requested": "latest.release"
         },
         "commons-lang:commons-lang": {
@@ -1166,12 +1238,16 @@
             "requested": "5.0.1.201806211838-r"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk7": {
-            "locked": "1.3.0",
+            "locked": "1.3.11",
             "requested": "1.3.0"
         },
         "org.ow2.asm:asm": {
-            "locked": "7.0",
-            "requested": "7.0"
+            "locked": "7.1",
+            "requested": "7.+"
+        },
+        "org.ow2.asm:asm-commons": {
+            "locked": "7.1",
+            "requested": "7.+"
         },
         "org.ow2.asm:asm-util": {
             "locked": "5.2",
@@ -1188,15 +1264,15 @@
             "requested": "19.0"
         },
         "com.netflix.nebula:gradle-info-plugin": {
-            "locked": "4.0.3",
+            "locked": "5.0.0",
             "requested": "latest.release"
         },
         "com.netflix.nebula:nebula-gradle-interop": {
-            "locked": "1.0.2",
+            "locked": "1.0.3",
             "requested": "latest.release"
         },
         "com.netflix.nebula:nebula-test": {
-            "locked": "7.1.7",
+            "locked": "7.1.8",
             "requested": "latest.release"
         },
         "commons-lang:commons-lang": {
@@ -1232,12 +1308,16 @@
             "requested": "5.0.1.201806211838-r"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk7": {
-            "locked": "1.3.0",
+            "locked": "1.3.11",
             "requested": "1.3.0"
         },
         "org.ow2.asm:asm": {
-            "locked": "7.0",
-            "requested": "7.0"
+            "locked": "7.1",
+            "requested": "7.+"
+        },
+        "org.ow2.asm:asm-commons": {
+            "locked": "7.1",
+            "requested": "7.+"
         },
         "org.ow2.asm:asm-util": {
             "locked": "5.2",

--- a/src/main/groovy/com/netflix/nebula/lint/rule/dependency/MethodReference.groovy
+++ b/src/main/groovy/com/netflix/nebula/lint/rule/dependency/MethodReference.groovy
@@ -19,6 +19,6 @@ class MethodReference {
 
     @Override
     String toString() {
-        return "class: $className | methodName: $methodName | owner: $owner | methodDesc: $methodDesc | line: $line | isInterface: $isInterface"
+        return "className: $className | methodName: $methodName | owner: $owner | methodDesc: $methodDesc | line: $line | isInterface: $isInterface"
     }
 }

--- a/src/main/groovy/com/netflix/nebula/lint/rule/dependency/MethodReference.groovy
+++ b/src/main/groovy/com/netflix/nebula/lint/rule/dependency/MethodReference.groovy
@@ -1,0 +1,24 @@
+package com.netflix.nebula.lint.rule.dependency
+
+class MethodReference {
+    String className
+    String methodName
+    String owner
+    String methodDesc
+    int line
+    boolean isInterface
+
+    MethodReference(String className, String methodName, String owner, String methodDesc, int line, boolean isInterface) {
+        this.className = className
+        this.methodName = methodName
+        this.owner = owner
+        this.methodDesc = methodDesc
+        this.line = line
+        this.isInterface = isInterface
+    }
+
+    @Override
+    String toString() {
+        return "class: $className | methodName: $methodName | owner: $owner | methodDesc: $methodDesc | line: $line | isInterface: $isInterface"
+    }
+}

--- a/src/main/groovy/com/netflix/nebula/lint/rule/dependency/MethodScanner.groovy
+++ b/src/main/groovy/com/netflix/nebula/lint/rule/dependency/MethodScanner.groovy
@@ -1,0 +1,101 @@
+package com.netflix.nebula.lint.rule.dependency
+
+import org.objectweb.asm.ClassReader
+import org.objectweb.asm.ClassVisitor
+import org.objectweb.asm.Label
+import org.objectweb.asm.MethodVisitor
+import org.objectweb.asm.Opcodes
+
+import java.nio.file.Path
+
+/**
+ * Scans a given class and retrieves information about method references.
+ * By default, ignores java/lang package.
+ */
+class MethodScanner {
+    private AppClassVisitor classVisitor
+
+    private ArrayList<MethodReference> methodReferences = []
+
+    private class AppMethodVisitor extends MethodVisitor {
+
+        int line
+
+        private final Collection<String> ignoredPackages
+
+        AppMethodVisitor(Collection<String> ignoredPackages) {
+            super(Opcodes.ASM6)
+            this.ignoredPackages = ignoredPackages
+        }
+
+        @Override
+        void visitMethodInsn(int opcode, String owner, String name, String desc, boolean isInterface) {
+            boolean isIgnoredPackage = ignoredPackages.any { ignoredPackage ->
+                owner.startsWith(ignoredPackage)
+            }
+            if(isIgnoredPackage) {
+                return
+            }
+            methodReferences.add(new MethodReference(
+                    classVisitor.className,
+                    name,
+                    owner,
+                    desc,
+                    line,
+                    isInterface
+                )
+            )
+        }
+
+        void visitLineNumber(int line, Label start) {
+            this.line = line
+        }
+    }
+
+    private class AppClassVisitor extends ClassVisitor {
+
+        private final AppMethodVisitor methodVisitor
+
+        public String source
+        public String className
+        public String methodName
+        public String methodDesc
+
+        AppClassVisitor(Collection<String> ignoredPackages) {
+            super(Opcodes.ASM6)
+            methodVisitor = new AppMethodVisitor(ignoredPackages)
+        }
+
+        @Override
+        void visit(int version, int access, String name,
+                   String signature, String superName, String[] interfaces) {
+            className = name
+        }
+
+        @Override
+        void visitSource(String source, String debug) {
+            this.source = source
+        }
+
+        @Override
+        MethodVisitor visitMethod(int access, String name,
+                                  String desc, String signature,
+                                  String[] exceptions) {
+            methodName = name
+            methodDesc = desc
+            return methodVisitor
+        }
+    }
+
+
+    Collection<MethodReference> findCallingMethods(Path toScan, Collection ignoredPackages) throws Exception {
+        BufferedInputStream stream = toScan.newInputStream()
+        stream.mark(Integer.MAX_VALUE)
+        this.classVisitor = new AppClassVisitor(ignoredPackages)
+        ClassReader reader = new ClassReader(stream)
+        reader.accept(classVisitor, 0)
+        stream.reset()
+        stream.close()
+        return methodReferences
+    }
+}

--- a/src/test/groovy/com/netflix/nebula/lint/rule/dependency/FindMethodReferencesSpec.groovy
+++ b/src/test/groovy/com/netflix/nebula/lint/rule/dependency/FindMethodReferencesSpec.groovy
@@ -51,9 +51,9 @@ class FindMethodReferencesSpec extends IntegrationSpec {
         String methodReferences =  new File(projectDir, 'compileMethodReferences.txt').text
 
         then:
-        !methodReferences.contains("class: Main | methodName: <init> | owner: java/lang/Object | methodDesc: ()V | line: 8")
-        methodReferences.contains("class: Main | methodName: sameThreadExecutor | owner: com/google/common/util/concurrent/MoreExecutors | methodDesc: ()Lcom/google/common/util/concurrent/ListeningExecutorService; | line: 9 | isInterface: false")
-        methodReferences.contains("class: Main | methodName: newSetFromMap | owner: com/google/common/collect/Sets | methodDesc: (Ljava/util/Map;)Ljava/util/Set; | line: 10 | isInterface: false")
+        !methodReferences.contains("className: Main | methodName: <init> | owner: java/lang/Object | methodDesc: ()V | line: 8")
+        methodReferences.contains("className: Main | methodName: sameThreadExecutor | owner: com/google/common/util/concurrent/MoreExecutors | methodDesc: ()Lcom/google/common/util/concurrent/ListeningExecutorService; | line: 9 | isInterface: false")
+        methodReferences.contains("className: Main | methodName: newSetFromMap | owner: com/google/common/collect/Sets | methodDesc: (Ljava/util/Map;)Ljava/util/Set; | line: 10 | isInterface: false")
     }
 
     def 'find method references - ignore package'() {
@@ -103,9 +103,9 @@ class FindMethodReferencesSpec extends IntegrationSpec {
         String methodReferences =  new File(projectDir, 'compileMethodReferences.txt').text
 
         then:
-        !methodReferences.contains("class: Main | methodName: <init> | owner: java/lang/Object | methodDesc: ()V | line: 8")
-        !methodReferences.contains("class: Main | methodName: newSetFromMap | owner: com/google/common/collect/Sets | methodDesc: (Ljava/util/Map;)Ljava/util/Set; | line: 10")
-        methodReferences.contains("class: Main | methodName: sameThreadExecutor | owner: com/google/common/util/concurrent/MoreExecutors | methodDesc: ()Lcom/google/common/util/concurrent/ListeningExecutorService; | line: 9 | isInterface: false")
+        !methodReferences.contains("className: Main | methodName: <init> | owner: java/lang/Object | methodDesc: ()V | line: 8")
+        !methodReferences.contains("className: Main | methodName: newSetFromMap | owner: com/google/common/collect/Sets | methodDesc: (Ljava/util/Map;)Ljava/util/Set; | line: 10")
+        methodReferences.contains("className: Main | methodName: sameThreadExecutor | owner: com/google/common/util/concurrent/MoreExecutors | methodDesc: ()Lcom/google/common/util/concurrent/ListeningExecutorService; | line: 9 | isInterface: false")
     }
 
     def 'find method references - multiple classes'() {
@@ -161,8 +161,8 @@ class FindMethodReferencesSpec extends IntegrationSpec {
         String methodReferences =  new File(projectDir, 'compileMethodReferences.txt').text
 
         then:
-        methodReferences.contains("class: Main | methodName: sameThreadExecutor | owner: com/google/common/util/concurrent/MoreExecutors | methodDesc: ()Lcom/google/common/util/concurrent/ListeningExecutorService; | line: 6 | isInterface: false")
-        methodReferences.contains("class: Main2 | methodName: newSetFromMap | owner: com/google/common/collect/Sets | methodDesc: (Ljava/util/Map;)Ljava/util/Set; | line: 7 | isInterface: false")
+        methodReferences.contains("className: Main | methodName: sameThreadExecutor | owner: com/google/common/util/concurrent/MoreExecutors | methodDesc: ()Lcom/google/common/util/concurrent/ListeningExecutorService; | line: 6 | isInterface: false")
+        methodReferences.contains("className: Main2 | methodName: newSetFromMap | owner: com/google/common/collect/Sets | methodDesc: (Ljava/util/Map;)Ljava/util/Set; | line: 7 | isInterface: false")
     }
 
 

--- a/src/test/groovy/com/netflix/nebula/lint/rule/dependency/FindMethodReferencesSpec.groovy
+++ b/src/test/groovy/com/netflix/nebula/lint/rule/dependency/FindMethodReferencesSpec.groovy
@@ -1,0 +1,182 @@
+package com.netflix.nebula.lint.rule.dependency
+
+import nebula.test.IntegrationSpec
+
+class FindMethodReferencesSpec extends IntegrationSpec {
+
+    def 'find method references'() {
+        buildFile.text = """\
+            import com.netflix.nebula.lint.rule.dependency.*
+
+            plugins {
+                id 'java'
+            }
+
+            apply plugin: 'nebula.lint'
+
+            repositories { mavenCentral() }
+            dependencies {
+                compile 'com.google.guava:guava:19.0'
+            }
+
+             // a task to generate an unused dependency report for each configuration
+            project.configurations.collect { it.name }.each { conf ->
+                task "\${conf}MethodReferences"(dependsOn: compileTestJava) {
+                    doLast {
+                        new File(projectDir, "\${conf}MethodReferences.txt").text = DependencyService.forProject(project)
+                        .methodReferences(conf)
+                        .join('\\n')
+                    }
+                  
+                }
+            }
+            """.stripMargin()
+
+        createJavaSourceFile("""
+           import com.google.common.collect.Sets;
+           import com.google.common.util.concurrent.ListeningExecutorService;
+           import com.google.common.util.concurrent.MoreExecutors;
+           import java.util.HashMap;
+           import java.util.Set;
+           
+           public class Main {
+               ListeningExecutorService les = MoreExecutors.sameThreadExecutor();
+               Set<String> tester = Sets.newSetFromMap(new HashMap<>());
+           }
+        """)
+
+
+        when:
+        runTasksSuccessfully('compileMethodReferences')
+        String methodReferences =  new File(projectDir, 'compileMethodReferences.txt').text
+
+        then:
+        !methodReferences.contains("class: Main | methodName: <init> | owner: java/lang/Object | methodDesc: ()V | line: 8")
+        methodReferences.contains("class: Main | methodName: sameThreadExecutor | owner: com/google/common/util/concurrent/MoreExecutors | methodDesc: ()Lcom/google/common/util/concurrent/ListeningExecutorService; | line: 9 | isInterface: false")
+        methodReferences.contains("class: Main | methodName: newSetFromMap | owner: com/google/common/collect/Sets | methodDesc: (Ljava/util/Map;)Ljava/util/Set; | line: 10 | isInterface: false")
+    }
+
+    def 'find method references - ignore package'() {
+        buildFile.text = """\
+            import com.netflix.nebula.lint.rule.dependency.*
+
+            plugins {
+                id 'java'
+            }
+
+            apply plugin: 'nebula.lint'
+
+            repositories { mavenCentral() }
+            dependencies {
+                compile 'com.google.guava:guava:19.0'
+            }
+
+             // a task to generate an unused dependency report for each configuration
+            project.configurations.collect { it.name }.each { conf ->
+                task "\${conf}MethodReferences"(dependsOn: compileTestJava) {
+                    doLast {
+                        new File(projectDir, "\${conf}MethodReferences.txt").text = DependencyService.forProject(project)
+                        .methodReferences(conf, ['com/google/common/collect'])
+                        .join('\\n')
+                    }
+                  
+                }
+            }
+            """.stripMargin()
+
+        createJavaSourceFile("""
+           import com.google.common.collect.Sets;
+           import com.google.common.util.concurrent.ListeningExecutorService;
+           import com.google.common.util.concurrent.MoreExecutors;
+           import java.util.HashMap;
+           import java.util.Set;
+           
+           public class Main {
+               ListeningExecutorService les = MoreExecutors.sameThreadExecutor();
+               Set<String> tester = Sets.newSetFromMap(new HashMap<>());
+           }
+        """)
+
+
+        when:
+        runTasksSuccessfully('compileMethodReferences')
+        String methodReferences =  new File(projectDir, 'compileMethodReferences.txt').text
+
+        then:
+        !methodReferences.contains("class: Main | methodName: <init> | owner: java/lang/Object | methodDesc: ()V | line: 8")
+        !methodReferences.contains("class: Main | methodName: newSetFromMap | owner: com/google/common/collect/Sets | methodDesc: (Ljava/util/Map;)Ljava/util/Set; | line: 10")
+        methodReferences.contains("class: Main | methodName: sameThreadExecutor | owner: com/google/common/util/concurrent/MoreExecutors | methodDesc: ()Lcom/google/common/util/concurrent/ListeningExecutorService; | line: 9 | isInterface: false")
+    }
+
+    def 'find method references - multiple classes'() {
+        buildFile.text = """\
+            import com.netflix.nebula.lint.rule.dependency.*
+
+            plugins {
+                id 'java'
+            }
+
+            apply plugin: 'nebula.lint'
+
+            repositories { mavenCentral() }
+            dependencies {
+                compile 'com.google.guava:guava:19.0'
+            }
+
+             // a task to generate an unused dependency report for each configuration
+            project.configurations.collect { it.name }.each { conf ->
+                task "\${conf}MethodReferences"(dependsOn: compileTestJava) {
+                    doLast {
+                        new File(projectDir, "\${conf}MethodReferences.txt").text = DependencyService.forProject(project)
+                        .methodReferences(conf)
+                        .join('\\n')
+                    }
+                  
+                }
+            }
+            """.stripMargin()
+
+        createJavaSourceFile("""
+           import com.google.common.util.concurrent.ListeningExecutorService;
+           import com.google.common.util.concurrent.MoreExecutors;
+           
+           public class Main {
+               ListeningExecutorService les = MoreExecutors.sameThreadExecutor();
+           }
+        """)
+
+        createJavaSourceFile("""
+           import com.google.common.collect.Sets;
+           import java.util.HashMap;
+           import java.util.Set;
+           
+           public class Main2 {
+               Set<String> tester = Sets.newSetFromMap(new HashMap<>());
+           }
+        """)
+
+
+        when:
+        runTasksSuccessfully('compileMethodReferences')
+        String methodReferences =  new File(projectDir, 'compileMethodReferences.txt').text
+
+        then:
+        methodReferences.contains("class: Main | methodName: sameThreadExecutor | owner: com/google/common/util/concurrent/MoreExecutors | methodDesc: ()Lcom/google/common/util/concurrent/ListeningExecutorService; | line: 6 | isInterface: false")
+        methodReferences.contains("class: Main2 | methodName: newSetFromMap | owner: com/google/common/collect/Sets | methodDesc: (Ljava/util/Map;)Ljava/util/Set; | line: 7 | isInterface: false")
+    }
+
+
+    def createJavaSourceFile(String source) {
+        createJavaSourceFile(projectDir, source)
+    }
+
+    def createJavaSourceFile(File projectDir, String source) {
+        createJavaFile(projectDir, source, 'src/main/java')
+    }
+
+    def createJavaFile(File projectDir, String source, String sourceFolderPath) {
+        def sourceFolder = new File(projectDir, sourceFolderPath)
+        sourceFolder.mkdirs()
+        new File(sourceFolder, JavaFixture.fullyQualifiedName(source).replaceAll(/\./, '/') + '.java').text = source
+    }
+}

--- a/src/test/groovy/com/netflix/nebula/lint/rule/dependency/FindMethodReferencesSpec.groovy
+++ b/src/test/groovy/com/netflix/nebula/lint/rule/dependency/FindMethodReferencesSpec.groovy
@@ -4,7 +4,7 @@ import nebula.test.IntegrationSpec
 
 class FindMethodReferencesSpec extends IntegrationSpec {
 
-    def 'find method references'() {
+    def 'find method references no exclusion'() {
         buildFile.text = """\
             import com.netflix.nebula.lint.rule.dependency.*
 
@@ -51,12 +51,13 @@ class FindMethodReferencesSpec extends IntegrationSpec {
         String methodReferences =  new File(projectDir, 'compileMethodReferences.txt').text
 
         then:
-        !methodReferences.contains("className: Main | methodName: <init> | owner: java/lang/Object | methodDesc: ()V | line: 8")
+        methodReferences.contains("className: Main | methodName: <init> | owner: java/lang/Object | methodDesc: ()V | line: 8")
         methodReferences.contains("className: Main | methodName: sameThreadExecutor | owner: com/google/common/util/concurrent/MoreExecutors | methodDesc: ()Lcom/google/common/util/concurrent/ListeningExecutorService; | line: 9 | isInterface: false")
         methodReferences.contains("className: Main | methodName: newSetFromMap | owner: com/google/common/collect/Sets | methodDesc: (Ljava/util/Map;)Ljava/util/Set; | line: 10 | isInterface: false")
     }
 
-    def 'find method references - ignore package'() {
+
+    def 'find method references excluding'() {
         buildFile.text = """\
             import com.netflix.nebula.lint.rule.dependency.*
 
@@ -76,7 +77,112 @@ class FindMethodReferencesSpec extends IntegrationSpec {
                 task "\${conf}MethodReferences"(dependsOn: compileTestJava) {
                     doLast {
                         new File(projectDir, "\${conf}MethodReferences.txt").text = DependencyService.forProject(project)
-                        .methodReferences(conf, ['com/google/common/collect'])
+                        .methodReferencesExcluding(conf)
+                        .join('\\n')
+                    }
+                  
+                }
+            }
+            """.stripMargin()
+
+        createJavaSourceFile("""
+           import com.google.common.collect.Sets;
+           import com.google.common.util.concurrent.ListeningExecutorService;
+           import com.google.common.util.concurrent.MoreExecutors;
+           import java.util.HashMap;
+           import java.util.Set;
+           
+           public class Main {
+               ListeningExecutorService les = MoreExecutors.sameThreadExecutor();
+               Set<String> tester = Sets.newSetFromMap(new HashMap<>());
+           }
+        """)
+
+
+        when:
+        runTasksSuccessfully('compileMethodReferences')
+        String methodReferences =  new File(projectDir, 'compileMethodReferences.txt').text
+
+        then:
+        !methodReferences.contains("className: Main | methodName: <init> | owner: java/lang/Object | methodDesc: ()V | line: 8")
+        methodReferences.contains("className: Main | methodName: sameThreadExecutor | owner: com/google/common/util/concurrent/MoreExecutors | methodDesc: ()Lcom/google/common/util/concurrent/ListeningExecutorService; | line: 9 | isInterface: false")
+        methodReferences.contains("className: Main | methodName: newSetFromMap | owner: com/google/common/collect/Sets | methodDesc: (Ljava/util/Map;)Ljava/util/Set; | line: 10 | isInterface: false")
+    }
+
+    def 'find method references - include only'() {
+        buildFile.text = """\
+            import com.netflix.nebula.lint.rule.dependency.*
+
+            plugins {
+                id 'java'
+            }
+
+            apply plugin: 'nebula.lint'
+
+            repositories { mavenCentral() }
+            dependencies {
+                compile 'com.google.guava:guava:19.0'
+            }
+
+             // a task to generate an unused dependency report for each configuration
+            project.configurations.collect { it.name }.each { conf ->
+                task "\${conf}MethodReferences"(dependsOn: compileTestJava) {
+                    doLast {
+                        new File(projectDir, "\${conf}MethodReferences.txt").text = DependencyService.forProject(project)
+                        .methodReferencesIncludeOnly(conf, ['com/google/common/collect'])
+                        .join('\\n')
+                    }
+                  
+                }
+            }
+            """.stripMargin()
+
+        createJavaSourceFile("""
+           import com.google.common.collect.Sets;
+           import com.google.common.util.concurrent.ListeningExecutorService;
+           import com.google.common.util.concurrent.MoreExecutors;
+           import java.util.HashMap;
+           import java.util.Set;
+           
+           public class Main {
+               ListeningExecutorService les = MoreExecutors.sameThreadExecutor();
+               Set<String> tester = Sets.newSetFromMap(new HashMap<>());
+           }
+        """)
+
+
+        when:
+        def r = runTasksSuccessfully('compileMethodReferences')
+        String methodReferences =  new File(projectDir, 'compileMethodReferences.txt').text
+
+        then:
+        !methodReferences.contains("className: Main | methodName: <init> | owner: java/lang/Object | methodDesc: ()V | line: 8")
+        !methodReferences.contains("className: Main | methodName: sameThreadExecutor | owner: com/google/common/util/concurrent/MoreExecutors | methodDesc: ()Lcom/google/common/util/concurrent/ListeningExecutorService; | line: 9 | isInterface: false")
+        methodReferences.contains("className: Main | methodName: newSetFromMap | owner: com/google/common/collect/Sets | methodDesc: (Ljava/util/Map;)Ljava/util/Set; | line: 10 | isInterface: false")
+    }
+
+
+    def 'find method references - exclude specific package'() {
+        buildFile.text = """\
+            import com.netflix.nebula.lint.rule.dependency.*
+
+            plugins {
+                id 'java'
+            }
+
+            apply plugin: 'nebula.lint'
+
+            repositories { mavenCentral() }
+            dependencies {
+                compile 'com.google.guava:guava:19.0'
+            }
+
+             // a task to generate an unused dependency report for each configuration
+            project.configurations.collect { it.name }.each { conf ->
+                task "\${conf}MethodReferences"(dependsOn: compileTestJava) {
+                    doLast {
+                        new File(projectDir, "\${conf}MethodReferences.txt").text = DependencyService.forProject(project)
+                        .methodReferencesExcluding(conf, ['com/google/common/collect'])
                         .join('\\n')
                     }
                   
@@ -128,7 +234,7 @@ class FindMethodReferencesSpec extends IntegrationSpec {
                 task "\${conf}MethodReferences"(dependsOn: compileTestJava) {
                     doLast {
                         new File(projectDir, "\${conf}MethodReferences.txt").text = DependencyService.forProject(project)
-                        .methodReferences(conf)
+                        .methodReferencesExcluding(conf)
                         .join('\\n')
                     }
                   


### PR DESCRIPTION
This enhance `DependencyService` to expose method level references.

For example:

```
import com.google.common.collect.Sets;
           import com.google.common.util.concurrent.ListeningExecutorService;
           import com.google.common.util.concurrent.MoreExecutors;
           import java.util.HashMap;
           import java.util.Set;
           
           public class Main {
               ListeningExecutorService les = MoreExecutors.sameThreadExecutor();
               Set<String> tester = Sets.newSetFromMap(new HashMap<>());
           }
```

Results in

```
className: Main | methodName: sameThreadExecutor | owner: com/google/common/util/concurrent/MoreExecutors | methodDesc: ()Lcom/google/common/util/concurrent/ListeningExecutorService; | line: 9 | isInterface: false
className: Main | methodName: newSetFromMap | owner: com/google/common/collect/Sets | methodDesc: (Ljava/util/Map;)Ljava/util/Set; | line: 10 | isInterface: false
```

Ignores common java packages to prevent a huge list of results:

```
"java/lang", "java/util", "java/net", "java/io", "java/nio", "java/swing"
``` 