### PR TITLE
Package references

### DIFF
--- a/src/main/groovy/com/netflix/nebula/lint/rule/dependency/ClassInformation.groovy
+++ b/src/main/groovy/com/netflix/nebula/lint/rule/dependency/ClassInformation.groovy
@@ -1,6 +1,7 @@
 package com.netflix.nebula.lint.rule.dependency
 
 class ClassInformation {
+    String filePath
     String source
     String name
 
@@ -10,10 +11,24 @@ class ClassInformation {
         this.source = source
         this.name = name
         this.methodReferences = methodReferences
+        this.filePath = calculateFilePath(source, name)
     }
 
     @Override
     String toString() {
-        return "source: $source - name: $name - methodReferences: ${methodReferences*.toString().join(' | ')}"
+        return "source: $source - filePath: $filePath - name: $name - methodReferences: ${methodReferences*.toString().join(' | ')}"
+    }
+
+    private String calculateFilePath(String source, String name) {
+        String extension = getFileExtension(source)
+        return name + extension
+    }
+
+    private String getFileExtension(String fileName) {
+        int lastIndexOf = fileName.lastIndexOf(".")
+        if (lastIndexOf == -1) {
+            return ""
+        }
+        return fileName.substring(lastIndexOf)
     }
 }

--- a/src/main/groovy/com/netflix/nebula/lint/rule/dependency/ClassInformation.groovy
+++ b/src/main/groovy/com/netflix/nebula/lint/rule/dependency/ClassInformation.groovy
@@ -1,0 +1,19 @@
+package com.netflix.nebula.lint.rule.dependency
+
+class ClassInformation {
+    String source
+    String name
+
+    Collection<MethodReference> methodReferences = []
+
+    ClassInformation(String source, String name, Collection<MethodReference> methodReferences) {
+        this.source = source
+        this.name = name
+        this.methodReferences = methodReferences
+    }
+
+    @Override
+    String toString() {
+        return "source: $source - name: $name - methodReferences: ${methodReferences*.toString().join(' | ')}"
+    }
+}

--- a/src/main/groovy/com/netflix/nebula/lint/rule/dependency/DependencyService.groovy
+++ b/src/main/groovy/com/netflix/nebula/lint/rule/dependency/DependencyService.groovy
@@ -171,7 +171,7 @@ class DependencyService {
      * @return
      */
     @Memoized
-    Collection<MethodReference> methodReferences(String confName) {
+    Collection<ClassInformation> methodReferences(String confName) {
         return findMethodReferences(confName, Collections.EMPTY_LIST,  Collections.EMPTY_LIST)
     }
 
@@ -184,7 +184,7 @@ class DependencyService {
      * @return
      */
     @Memoized
-    Collection<MethodReference> methodReferencesExcluding(String confName,  Collection<String> ignoredPackages = []) {
+    Collection<ClassInformation> methodReferencesExcluding(String confName,  Collection<String> ignoredPackages = []) {
         return findMethodReferences(confName, Collections.EMPTY_LIST,  ignoredPackages + DEFAULT_METHOD_REFERENCE_IGNORED_PACKAGES)
     }
 
@@ -196,25 +196,25 @@ class DependencyService {
      * @return
      */
     @Memoized
-    Collection<MethodReference> methodReferencesIncludeOnly(String confName, Collection<String> includeOnlyPackages) {
+    Collection<ClassInformation> methodReferencesIncludeOnly(String confName, Collection<String> includeOnlyPackages) {
         return findMethodReferences(confName, includeOnlyPackages,  Collections.EMPTY_LIST)
     }
 
-    private Collection<MethodReference> findMethodReferences(String confName, Collection<String> includeOnlyPackages, Collection<String> ignoredPackages ) {
-        Collection<MethodReference> allReferences = []
+    private Collection<ClassInformation> findMethodReferences(String confName, Collection<String> includeOnlyPackages, Collection<String> ignoredPackages ) {
+        Collection<ClassInformation> classesInfo = []
         sourceSetOutput(confName).files.findAll { it.exists() }.each { output ->
             Files.walkFileTree(output.toPath(), new SimpleFileVisitor<Path>() {
                 @Override
                 FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
                     if (file.toFile().name.endsWith('.class')) {
-                        Collection<MethodReference> references = new MethodScanner().findCallingMethods(file, includeOnlyPackages, ignoredPackages)
-                        allReferences.addAll(references)
+                        ClassInformation classInformation = new MethodScanner().findMethodReferences(file, includeOnlyPackages, ignoredPackages)
+                        classesInfo.add(classInformation)
                     }
                     return FileVisitResult.CONTINUE
                 }
             })
         }
-        return allReferences
+        return classesInfo
     }
 
     @Memoized

--- a/src/main/groovy/com/netflix/nebula/lint/rule/dependency/DependencyService.groovy
+++ b/src/main/groovy/com/netflix/nebula/lint/rule/dependency/DependencyService.groovy
@@ -252,10 +252,6 @@ class DependencyService {
                 }
             })
         }
-        references.each {
-            println it.dump()
-        }
-
         return references
     }
 

--- a/src/main/groovy/com/netflix/nebula/lint/rule/dependency/DependencyService.groovy
+++ b/src/main/groovy/com/netflix/nebula/lint/rule/dependency/DependencyService.groovy
@@ -201,13 +201,14 @@ class DependencyService {
     }
 
     private Collection<ClassInformation> findMethodReferences(String confName, Collection<String> includeOnlyPackages, Collection<String> ignoredPackages ) {
+        Map<String, Collection<ResolvedArtifact>> artifactsByClass = artifactsByClass(confName)
         Collection<ClassInformation> classesInfo = []
         sourceSetOutput(confName).files.findAll { it.exists() }.each { output ->
             Files.walkFileTree(output.toPath(), new SimpleFileVisitor<Path>() {
                 @Override
                 FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
                     if (file.toFile().name.endsWith('.class')) {
-                        ClassInformation classInformation = new MethodScanner().findMethodReferences(file, includeOnlyPackages, ignoredPackages)
+                        ClassInformation classInformation = new MethodScanner().findMethodReferences(artifactsByClass, file, includeOnlyPackages, ignoredPackages)
                         classesInfo.add(classInformation)
                     }
                     return FileVisitResult.CONTINUE
@@ -250,6 +251,9 @@ class DependencyService {
                     return FileVisitResult.CONTINUE
                 }
             })
+        }
+        references.each {
+            println it.dump()
         }
 
         return references

--- a/src/main/groovy/com/netflix/nebula/lint/rule/dependency/MethodReference.groovy
+++ b/src/main/groovy/com/netflix/nebula/lint/rule/dependency/MethodReference.groovy
@@ -1,5 +1,6 @@
 package com.netflix.nebula.lint.rule.dependency
 
+
 class MethodReference {
     String methodName
     String owner
@@ -7,14 +8,16 @@ class MethodReference {
     int line
     boolean isInterface
     OpCode opCode
+    Collection<ResolvedArtifactInfo> artifacts
 
-    MethodReference(String methodName, String owner, String methodDesc, int line, boolean isInterface, int code) {
+    MethodReference(String methodName, String owner, String methodDesc, int line, boolean isInterface, int code, Collection<ResolvedArtifactInfo> artifacts) {
         this.methodName = methodName
         this.owner = owner
         this.methodDesc = methodDesc
         this.line = line
         this.isInterface = isInterface
         this.opCode = OpCode.findByCode(code)
+        this.artifacts = artifacts
     }
 
     @Override

--- a/src/main/groovy/com/netflix/nebula/lint/rule/dependency/MethodReference.groovy
+++ b/src/main/groovy/com/netflix/nebula/lint/rule/dependency/MethodReference.groovy
@@ -1,7 +1,6 @@
 package com.netflix.nebula.lint.rule.dependency
 
 class MethodReference {
-    String className
     String methodName
     String owner
     String methodDesc
@@ -9,8 +8,7 @@ class MethodReference {
     boolean isInterface
     OpCode opCode
 
-    MethodReference(String className, String methodName, String owner, String methodDesc, int line, boolean isInterface, int code) {
-        this.className = className
+    MethodReference(String methodName, String owner, String methodDesc, int line, boolean isInterface, int code) {
         this.methodName = methodName
         this.owner = owner
         this.methodDesc = methodDesc
@@ -21,7 +19,7 @@ class MethodReference {
 
     @Override
     String toString() {
-        return "className: $className | methodName: $methodName | owner: $owner | methodDesc: $methodDesc | line: $line | isInterface: $isInterface | opCode: ${opCode.name()}"
+        return "methodName: $methodName - owner: $owner - methodDesc: $methodDesc - line: $line - isInterface: $isInterface - opCode: ${opCode.name()}"
     }
 
     enum OpCode {

--- a/src/main/groovy/com/netflix/nebula/lint/rule/dependency/MethodScanner.groovy
+++ b/src/main/groovy/com/netflix/nebula/lint/rule/dependency/MethodScanner.groovy
@@ -39,7 +39,6 @@ class MethodScanner {
                 return
             }
             methodReferences.add(new MethodReference(
-                    classVisitor.className,
                     name,
                     owner,
                     desc,
@@ -66,7 +65,7 @@ class MethodScanner {
 
         AppClassVisitor(Collection<String> includeOnlyPackages, Collection<String> ignoredPackages) {
             super(Opcodes.ASM6)
-            methodVisitor = new AppMethodVisitor(includeOnlyPackages, ignoredPackages)
+            this.methodVisitor = new AppMethodVisitor(includeOnlyPackages, ignoredPackages)
         }
 
         @Override
@@ -91,7 +90,7 @@ class MethodScanner {
     }
 
 
-    Collection<MethodReference> findCallingMethods(Path toScan, Collection<String> includeOnlyPackages, Collection<String> ignoredPackages) throws Exception {
+    ClassInformation findMethodReferences(Path toScan, Collection<String> includeOnlyPackages, Collection<String> ignoredPackages) throws Exception {
         BufferedInputStream stream = toScan.newInputStream()
         stream.mark(Integer.MAX_VALUE)
         this.classVisitor = new AppClassVisitor(includeOnlyPackages, ignoredPackages)
@@ -99,6 +98,6 @@ class MethodScanner {
         reader.accept(classVisitor, 0)
         stream.reset()
         stream.close()
-        return methodReferences
+        return new ClassInformation(classVisitor.source, classVisitor.className, methodReferences)
     }
 }

--- a/src/main/groovy/com/netflix/nebula/lint/rule/dependency/MethodScanner.groovy
+++ b/src/main/groovy/com/netflix/nebula/lint/rule/dependency/MethodScanner.groovy
@@ -1,5 +1,6 @@
 package com.netflix.nebula.lint.rule.dependency
 
+import org.gradle.api.artifacts.ResolvedArtifact
 import org.objectweb.asm.ClassReader
 import org.objectweb.asm.ClassVisitor
 import org.objectweb.asm.Label
@@ -23,11 +24,13 @@ class MethodScanner {
 
         private final Collection<String> ignoredPackages
         private final Collection<String> includeOnlyPackages
+        private final Map<String, Collection<ResolvedArtifact>> artifactsByClass
 
-        AppMethodVisitor(Collection<String> includeOnlyPackages, Collection<String> ignoredPackages) {
+        AppMethodVisitor(Map<String, Collection<ResolvedArtifact>> artifactsByClass, Collection<String> includeOnlyPackages, Collection<String> ignoredPackages) {
             super(Opcodes.ASM6)
             this.ignoredPackages = ignoredPackages
             this.includeOnlyPackages = includeOnlyPackages
+            this.artifactsByClass = artifactsByClass
         }
 
         @Override
@@ -38,13 +41,17 @@ class MethodScanner {
             if (ignoredPackages.any { ignoredPackage -> owner.startsWith(ignoredPackage) }) {
                 return
             }
+
+            Collection<ResolvedArtifact> artifacts = artifactsByClass.get(owner)
+
             methodReferences.add(new MethodReference(
                     name,
                     owner,
                     desc,
                     line,
                     isInterface,
-                    opcode
+                    opcode,
+                    artifacts.collect { ResolvedArtifactInfo.fromResolvedArtifact(it)}
             )
             )
         }
@@ -63,9 +70,9 @@ class MethodScanner {
         public String methodName
         public String methodDesc
 
-        AppClassVisitor(Collection<String> includeOnlyPackages, Collection<String> ignoredPackages) {
+        AppClassVisitor(Map<String, Collection<ResolvedArtifact>> artifactsByClass, Collection<String> includeOnlyPackages, Collection<String> ignoredPackages) {
             super(Opcodes.ASM6)
-            this.methodVisitor = new AppMethodVisitor(includeOnlyPackages, ignoredPackages)
+            this.methodVisitor = new AppMethodVisitor(artifactsByClass, includeOnlyPackages, ignoredPackages)
         }
 
         @Override
@@ -90,10 +97,10 @@ class MethodScanner {
     }
 
 
-    ClassInformation findMethodReferences(Path toScan, Collection<String> includeOnlyPackages, Collection<String> ignoredPackages) throws Exception {
+    ClassInformation findMethodReferences(Map<String, Collection<ResolvedArtifact>> artifactsByClass, Path toScan, Collection<String> includeOnlyPackages, Collection<String> ignoredPackages) throws Exception {
         BufferedInputStream stream = toScan.newInputStream()
         stream.mark(Integer.MAX_VALUE)
-        this.classVisitor = new AppClassVisitor(includeOnlyPackages, ignoredPackages)
+        this.classVisitor = new AppClassVisitor(artifactsByClass, includeOnlyPackages, ignoredPackages)
         ClassReader reader = new ClassReader(stream)
         reader.accept(classVisitor, 0)
         stream.reset()

--- a/src/main/groovy/com/netflix/nebula/lint/rule/dependency/ResolvedArtifactInfo.groovy
+++ b/src/main/groovy/com/netflix/nebula/lint/rule/dependency/ResolvedArtifactInfo.groovy
@@ -1,0 +1,19 @@
+package com.netflix.nebula.lint.rule.dependency
+
+import org.gradle.api.artifacts.ResolvedArtifact
+
+class ResolvedArtifactInfo {
+    String organization
+    String name
+    String version
+    String type
+
+    static ResolvedArtifactInfo fromResolvedArtifact(ResolvedArtifact resolvedArtifact) {
+        ResolvedArtifactInfo info = new ResolvedArtifactInfo()
+        info.organization = resolvedArtifact.moduleVersion.id.group
+        info.name = resolvedArtifact.moduleVersion.id.name
+        info.version = resolvedArtifact.moduleVersion.id.version
+        info.type = resolvedArtifact.type
+        return info
+    }
+}

--- a/src/test/groovy/com/netflix/nebula/lint/rule/dependency/FindMethodReferencesSpec.groovy
+++ b/src/test/groovy/com/netflix/nebula/lint/rule/dependency/FindMethodReferencesSpec.groovy
@@ -270,8 +270,8 @@ class FindMethodReferencesSpec extends IntegrationSpec {
         String methodReferences =  new File(projectDir, 'compileMethodReferences.txt').text
 
         then:
-        methodReferences == "source: Main2.java - filePath: com/netflix/test/Main2.java - name: com/netflix/test/Main2 - methodReferences: methodName: newSetFromMap - owner: com/google/common/collect/Sets - methodDesc: (Ljava/util/Map;)Ljava/util/Set; - line: 9 - isInterface: false - opCode: INVOKESTATIC\n" +
-                "source: Main.java - filePath: com/netflix/test/Main.java - name: com/netflix/test/Main - methodReferences: methodName: sameThreadExecutor - owner: com/google/common/util/concurrent/MoreExecutors - methodDesc: ()Lcom/google/common/util/concurrent/ListeningExecutorService; - line: 8 - isInterface: false - opCode: INVOKESTATIC"
+        methodReferences.contains "source: Main2.java - filePath: com/netflix/test/Main2.java - name: com/netflix/test/Main2 - methodReferences: methodName: newSetFromMap - owner: com/google/common/collect/Sets - methodDesc: (Ljava/util/Map;)Ljava/util/Set; - line: 9 - isInterface: false - opCode: INVOKESTATIC"
+        methodReferences.contains "source: Main.java - filePath: com/netflix/test/Main.java - name: com/netflix/test/Main - methodReferences: methodName: sameThreadExecutor - owner: com/google/common/util/concurrent/MoreExecutors - methodDesc: ()Lcom/google/common/util/concurrent/ListeningExecutorService; - line: 8 - isInterface: false - opCode: INVOKESTATIC"
     }
 
 

--- a/src/test/groovy/com/netflix/nebula/lint/rule/dependency/FindMethodReferencesSpec.groovy
+++ b/src/test/groovy/com/netflix/nebula/lint/rule/dependency/FindMethodReferencesSpec.groovy
@@ -33,6 +33,8 @@ class FindMethodReferencesSpec extends IntegrationSpec {
             """.stripMargin()
 
         createJavaSourceFile("""
+           package com.netflix.test;
+
            import com.google.common.collect.Sets;
            import com.google.common.util.concurrent.ListeningExecutorService;
            import com.google.common.util.concurrent.MoreExecutors;
@@ -47,11 +49,11 @@ class FindMethodReferencesSpec extends IntegrationSpec {
 
 
         when:
-        runTasksSuccessfully('compileMethodReferences')
+        def x = runTasksSuccessfully('compileMethodReferences')
         String methodReferences =  new File(projectDir, 'compileMethodReferences.txt').text
 
         then:
-        methodReferences == "source: Main.java - name: Main - methodReferences: methodName: <init> - owner: java/lang/Object - methodDesc: ()V - line: 8 - isInterface: false - opCode: INVOKESPECIAL | methodName: sameThreadExecutor - owner: com/google/common/util/concurrent/MoreExecutors - methodDesc: ()Lcom/google/common/util/concurrent/ListeningExecutorService; - line: 9 - isInterface: false - opCode: INVOKESTATIC | methodName: <init> - owner: java/util/HashMap - methodDesc: ()V - line: 10 - isInterface: false - opCode: INVOKESPECIAL | methodName: newSetFromMap - owner: com/google/common/collect/Sets - methodDesc: (Ljava/util/Map;)Ljava/util/Set; - line: 10 - isInterface: false - opCode: INVOKESTATIC"
+        methodReferences == "source: Main.java - filePath: com/netflix/test/Main.java - name: com/netflix/test/Main - methodReferences: methodName: <init> - owner: java/lang/Object - methodDesc: ()V - line: 10 - isInterface: false - opCode: INVOKESPECIAL | methodName: sameThreadExecutor - owner: com/google/common/util/concurrent/MoreExecutors - methodDesc: ()Lcom/google/common/util/concurrent/ListeningExecutorService; - line: 11 - isInterface: false - opCode: INVOKESTATIC | methodName: <init> - owner: java/util/HashMap - methodDesc: ()V - line: 12 - isInterface: false - opCode: INVOKESPECIAL | methodName: newSetFromMap - owner: com/google/common/collect/Sets - methodDesc: (Ljava/util/Map;)Ljava/util/Set; - line: 12 - isInterface: false - opCode: INVOKESTATIC"
     }
 
 
@@ -84,6 +86,8 @@ class FindMethodReferencesSpec extends IntegrationSpec {
             """.stripMargin()
 
         createJavaSourceFile("""
+            package com.netflix.test;
+
            import com.google.common.collect.Sets;
            import com.google.common.util.concurrent.ListeningExecutorService;
            import com.google.common.util.concurrent.MoreExecutors;
@@ -102,7 +106,7 @@ class FindMethodReferencesSpec extends IntegrationSpec {
         String methodReferences =  new File(projectDir, 'compileMethodReferences.txt').text
 
         then:
-        methodReferences == "source: Main.java - name: Main - methodReferences: methodName: sameThreadExecutor - owner: com/google/common/util/concurrent/MoreExecutors - methodDesc: ()Lcom/google/common/util/concurrent/ListeningExecutorService; - line: 9 - isInterface: false - opCode: INVOKESTATIC | methodName: newSetFromMap - owner: com/google/common/collect/Sets - methodDesc: (Ljava/util/Map;)Ljava/util/Set; - line: 10 - isInterface: false - opCode: INVOKESTATIC"
+        methodReferences == "source: Main.java - filePath: com/netflix/test/Main.java - name: com/netflix/test/Main - methodReferences: methodName: sameThreadExecutor - owner: com/google/common/util/concurrent/MoreExecutors - methodDesc: ()Lcom/google/common/util/concurrent/ListeningExecutorService; - line: 11 - isInterface: false - opCode: INVOKESTATIC | methodName: newSetFromMap - owner: com/google/common/collect/Sets - methodDesc: (Ljava/util/Map;)Ljava/util/Set; - line: 12 - isInterface: false - opCode: INVOKESTATIC"
     }
 
     def 'find method references - include only'() {
@@ -134,6 +138,7 @@ class FindMethodReferencesSpec extends IntegrationSpec {
             """.stripMargin()
 
         createJavaSourceFile("""
+           package com.netflix.test;
            import com.google.common.collect.Sets;
            import com.google.common.util.concurrent.ListeningExecutorService;
            import com.google.common.util.concurrent.MoreExecutors;
@@ -152,7 +157,7 @@ class FindMethodReferencesSpec extends IntegrationSpec {
         String methodReferences =  new File(projectDir, 'compileMethodReferences.txt').text
 
         then:
-        methodReferences == "source: Main.java - name: Main - methodReferences: methodName: newSetFromMap - owner: com/google/common/collect/Sets - methodDesc: (Ljava/util/Map;)Ljava/util/Set; - line: 10 - isInterface: false - opCode: INVOKESTATIC"
+        methodReferences == "source: Main.java - filePath: com/netflix/test/Main.java - name: com/netflix/test/Main - methodReferences: methodName: newSetFromMap - owner: com/google/common/collect/Sets - methodDesc: (Ljava/util/Map;)Ljava/util/Set; - line: 11 - isInterface: false - opCode: INVOKESTATIC"
     }
 
 
@@ -185,6 +190,8 @@ class FindMethodReferencesSpec extends IntegrationSpec {
             """.stripMargin()
 
         createJavaSourceFile("""
+           package com.netflix.test;
+
            import com.google.common.collect.Sets;
            import com.google.common.util.concurrent.ListeningExecutorService;
            import com.google.common.util.concurrent.MoreExecutors;
@@ -203,7 +210,7 @@ class FindMethodReferencesSpec extends IntegrationSpec {
         String methodReferences =  new File(projectDir, 'compileMethodReferences.txt').text
 
         then:
-        methodReferences == "source: Main.java - name: Main - methodReferences: methodName: sameThreadExecutor - owner: com/google/common/util/concurrent/MoreExecutors - methodDesc: ()Lcom/google/common/util/concurrent/ListeningExecutorService; - line: 9 - isInterface: false - opCode: INVOKESTATIC"
+        methodReferences == "source: Main.java - filePath: com/netflix/test/Main.java - name: com/netflix/test/Main - methodReferences: methodName: sameThreadExecutor - owner: com/google/common/util/concurrent/MoreExecutors - methodDesc: ()Lcom/google/common/util/concurrent/ListeningExecutorService; - line: 11 - isInterface: false - opCode: INVOKESTATIC"
     }
 
     def 'find method references - multiple classes'() {
@@ -235,6 +242,8 @@ class FindMethodReferencesSpec extends IntegrationSpec {
             """.stripMargin()
 
         createJavaSourceFile("""
+           package com.netflix.test;
+
            import com.google.common.util.concurrent.ListeningExecutorService;
            import com.google.common.util.concurrent.MoreExecutors;
            
@@ -244,6 +253,8 @@ class FindMethodReferencesSpec extends IntegrationSpec {
         """)
 
         createJavaSourceFile("""
+           package com.netflix.test;
+           
            import com.google.common.collect.Sets;
            import java.util.HashMap;
            import java.util.Set;
@@ -259,8 +270,8 @@ class FindMethodReferencesSpec extends IntegrationSpec {
         String methodReferences =  new File(projectDir, 'compileMethodReferences.txt').text
 
         then:
-        methodReferences == "source: Main2.java - name: Main2 - methodReferences: methodName: newSetFromMap - owner: com/google/common/collect/Sets - methodDesc: (Ljava/util/Map;)Ljava/util/Set; - line: 7 - isInterface: false - opCode: INVOKESTATIC\n" +
-                "source: Main.java - name: Main - methodReferences: methodName: sameThreadExecutor - owner: com/google/common/util/concurrent/MoreExecutors - methodDesc: ()Lcom/google/common/util/concurrent/ListeningExecutorService; - line: 6 - isInterface: false - opCode: INVOKESTATIC"
+        methodReferences == "source: Main2.java - filePath: com/netflix/test/Main2.java - name: com/netflix/test/Main2 - methodReferences: methodName: newSetFromMap - owner: com/google/common/collect/Sets - methodDesc: (Ljava/util/Map;)Ljava/util/Set; - line: 9 - isInterface: false - opCode: INVOKESTATIC\n" +
+                "source: Main.java - filePath: com/netflix/test/Main.java - name: com/netflix/test/Main - methodReferences: methodName: sameThreadExecutor - owner: com/google/common/util/concurrent/MoreExecutors - methodDesc: ()Lcom/google/common/util/concurrent/ListeningExecutorService; - line: 8 - isInterface: false - opCode: INVOKESTATIC"
     }
 
 
@@ -269,12 +280,12 @@ class FindMethodReferencesSpec extends IntegrationSpec {
     }
 
     def createJavaSourceFile(File projectDir, String source) {
-        createJavaFile(projectDir, source, 'src/main/java')
+        createJavaFile(projectDir, source, 'src/main/java/com/netflix/test')
     }
 
     def createJavaFile(File projectDir, String source, String sourceFolderPath) {
         def sourceFolder = new File(projectDir, sourceFolderPath)
         sourceFolder.mkdirs()
-        new File(sourceFolder, JavaFixture.fullyQualifiedName(source).replaceAll(/\./, '/') + '.java').text = source
+        new File(projectDir.toString() + '/src/main/java', JavaFixture.fullyQualifiedName(source).replaceAll(/\./, '/') + '.java').text = source
     }
 }

--- a/src/test/groovy/com/netflix/nebula/lint/rule/dependency/FindMethodReferencesSpec.groovy
+++ b/src/test/groovy/com/netflix/nebula/lint/rule/dependency/FindMethodReferencesSpec.groovy
@@ -49,7 +49,7 @@ class FindMethodReferencesSpec extends IntegrationSpec {
 
 
         when:
-        def x = runTasksSuccessfully('compileMethodReferences')
+        runTasksSuccessfully('compileMethodReferences')
         String methodReferences =  new File(projectDir, 'compileMethodReferences.txt').text
 
         then:

--- a/src/test/groovy/com/netflix/nebula/lint/rule/dependency/FindMethodReferencesSpec.groovy
+++ b/src/test/groovy/com/netflix/nebula/lint/rule/dependency/FindMethodReferencesSpec.groovy
@@ -274,7 +274,6 @@ class FindMethodReferencesSpec extends IntegrationSpec {
         methodReferences.contains "source: Main.java - filePath: com/netflix/test/Main.java - name: com/netflix/test/Main - methodReferences: methodName: sameThreadExecutor - owner: com/google/common/util/concurrent/MoreExecutors - methodDesc: ()Lcom/google/common/util/concurrent/ListeningExecutorService; - line: 8 - isInterface: false - opCode: INVOKESTATIC"
     }
 
-
     def createJavaSourceFile(String source) {
         createJavaSourceFile(projectDir, source)
     }

--- a/src/test/groovy/com/netflix/nebula/lint/rule/dependency/FindMethodReferencesSpec.groovy
+++ b/src/test/groovy/com/netflix/nebula/lint/rule/dependency/FindMethodReferencesSpec.groovy
@@ -51,9 +51,7 @@ class FindMethodReferencesSpec extends IntegrationSpec {
         String methodReferences =  new File(projectDir, 'compileMethodReferences.txt').text
 
         then:
-        methodReferences.contains("className: Main | methodName: <init> | owner: java/lang/Object | methodDesc: ()V | line: 8")
-        methodReferences.contains("className: Main | methodName: sameThreadExecutor | owner: com/google/common/util/concurrent/MoreExecutors | methodDesc: ()Lcom/google/common/util/concurrent/ListeningExecutorService; | line: 9 | isInterface: false | opCode: INVOKESTATIC")
-        methodReferences.contains("className: Main | methodName: newSetFromMap | owner: com/google/common/collect/Sets | methodDesc: (Ljava/util/Map;)Ljava/util/Set; | line: 10 | isInterface: false | opCode: INVOKESTATIC")
+        methodReferences == "source: Main.java - name: Main - methodReferences: methodName: <init> - owner: java/lang/Object - methodDesc: ()V - line: 8 - isInterface: false - opCode: INVOKESPECIAL | methodName: sameThreadExecutor - owner: com/google/common/util/concurrent/MoreExecutors - methodDesc: ()Lcom/google/common/util/concurrent/ListeningExecutorService; - line: 9 - isInterface: false - opCode: INVOKESTATIC | methodName: <init> - owner: java/util/HashMap - methodDesc: ()V - line: 10 - isInterface: false - opCode: INVOKESPECIAL | methodName: newSetFromMap - owner: com/google/common/collect/Sets - methodDesc: (Ljava/util/Map;)Ljava/util/Set; - line: 10 - isInterface: false - opCode: INVOKESTATIC"
     }
 
 
@@ -104,9 +102,7 @@ class FindMethodReferencesSpec extends IntegrationSpec {
         String methodReferences =  new File(projectDir, 'compileMethodReferences.txt').text
 
         then:
-        !methodReferences.contains("className: Main | methodName: <init> | owner: java/lang/Object | methodDesc: ()V | line: 8")
-        methodReferences.contains("className: Main | methodName: sameThreadExecutor | owner: com/google/common/util/concurrent/MoreExecutors | methodDesc: ()Lcom/google/common/util/concurrent/ListeningExecutorService; | line: 9 | isInterface: false | opCode: INVOKESTATIC")
-        methodReferences.contains("className: Main | methodName: newSetFromMap | owner: com/google/common/collect/Sets | methodDesc: (Ljava/util/Map;)Ljava/util/Set; | line: 10 | isInterface: false | opCode: INVOKESTATIC")
+        methodReferences == "source: Main.java - name: Main - methodReferences: methodName: sameThreadExecutor - owner: com/google/common/util/concurrent/MoreExecutors - methodDesc: ()Lcom/google/common/util/concurrent/ListeningExecutorService; - line: 9 - isInterface: false - opCode: INVOKESTATIC | methodName: newSetFromMap - owner: com/google/common/collect/Sets - methodDesc: (Ljava/util/Map;)Ljava/util/Set; - line: 10 - isInterface: false - opCode: INVOKESTATIC"
     }
 
     def 'find method references - include only'() {
@@ -156,9 +152,7 @@ class FindMethodReferencesSpec extends IntegrationSpec {
         String methodReferences =  new File(projectDir, 'compileMethodReferences.txt').text
 
         then:
-        !methodReferences.contains("className: Main | methodName: <init> | owner: java/lang/Object | methodDesc: ()V | line: 8")
-        !methodReferences.contains("className: Main | methodName: sameThreadExecutor | owner: com/google/common/util/concurrent/MoreExecutors | methodDesc: ()Lcom/google/common/util/concurrent/ListeningExecutorService; | line: 9 | isInterface: false | opCode: INVOKESTATIC")
-        methodReferences.contains("className: Main | methodName: newSetFromMap | owner: com/google/common/collect/Sets | methodDesc: (Ljava/util/Map;)Ljava/util/Set; | line: 10 | isInterface: false | opCode: INVOKESTATIC")
+        methodReferences == "source: Main.java - name: Main - methodReferences: methodName: newSetFromMap - owner: com/google/common/collect/Sets - methodDesc: (Ljava/util/Map;)Ljava/util/Set; - line: 10 - isInterface: false - opCode: INVOKESTATIC"
     }
 
 
@@ -209,9 +203,7 @@ class FindMethodReferencesSpec extends IntegrationSpec {
         String methodReferences =  new File(projectDir, 'compileMethodReferences.txt').text
 
         then:
-        !methodReferences.contains("className: Main | methodName: <init> | owner: java/lang/Object | methodDesc: ()V | line: 8")
-        !methodReferences.contains("className: Main | methodName: newSetFromMap | owner: com/google/common/collect/Sets | methodDesc: (Ljava/util/Map;)Ljava/util/Set; | line: 10")
-        methodReferences.contains("className: Main | methodName: sameThreadExecutor | owner: com/google/common/util/concurrent/MoreExecutors | methodDesc: ()Lcom/google/common/util/concurrent/ListeningExecutorService; | line: 9 | isInterface: false | opCode: INVOKESTATIC")
+        methodReferences == "source: Main.java - name: Main - methodReferences: methodName: sameThreadExecutor - owner: com/google/common/util/concurrent/MoreExecutors - methodDesc: ()Lcom/google/common/util/concurrent/ListeningExecutorService; - line: 9 - isInterface: false - opCode: INVOKESTATIC"
     }
 
     def 'find method references - multiple classes'() {
@@ -267,8 +259,8 @@ class FindMethodReferencesSpec extends IntegrationSpec {
         String methodReferences =  new File(projectDir, 'compileMethodReferences.txt').text
 
         then:
-        methodReferences.contains("className: Main | methodName: sameThreadExecutor | owner: com/google/common/util/concurrent/MoreExecutors | methodDesc: ()Lcom/google/common/util/concurrent/ListeningExecutorService; | line: 6 | isInterface: false | opCode: INVOKESTATIC")
-        methodReferences.contains("className: Main2 | methodName: newSetFromMap | owner: com/google/common/collect/Sets | methodDesc: (Ljava/util/Map;)Ljava/util/Set; | line: 7 | isInterface: false | opCode: INVOKESTATIC")
+        methodReferences == "source: Main2.java - name: Main2 - methodReferences: methodName: newSetFromMap - owner: com/google/common/collect/Sets - methodDesc: (Ljava/util/Map;)Ljava/util/Set; - line: 7 - isInterface: false - opCode: INVOKESTATIC\n" +
+                "source: Main.java - name: Main - methodReferences: methodName: sameThreadExecutor - owner: com/google/common/util/concurrent/MoreExecutors - methodDesc: ()Lcom/google/common/util/concurrent/ListeningExecutorService; - line: 6 - isInterface: false - opCode: INVOKESTATIC"
     }
 
 


### PR DESCRIPTION
Heads up @OdysseusLives @chali 

This changes the contract a little bit to group by method references by class and also provide helpful information such as package for a given class which was missing before 

Example:

```
[
    {
        "methodReferences": [
            {
                "opCode": "INVOKESTATIC",
                "isInterface": false,
                "owner": "com/google/common/util/concurrent/MoreExecutors",
                "methodDesc": "()Lcom/google/common/util/concurrent/ListeningExecutorService;",
                "line": 11,
                "methodName": "sameThreadExecutor"
            },
            {
                "opCode": "INVOKESTATIC",
                "isInterface": false,
                "owner": "com/google/common/collect/Sets",
                "methodDesc": "(Ljava/util/Map;)Ljava/util/Set;",
                "line": 12,
                "methodName": "newSetFromMap"
            }
        ],
        "filePath": "com/netflix/test/Main.java",
        "source": "Main.java",
        "name": "com/netflix/test/Main"
    }
]
```