### PR TITLE
Modify how autoLint is executed at the end of the build

### DIFF
--- a/src/main/groovy/com/netflix/nebula/lint/plugin/GradleLintPlugin.groovy
+++ b/src/main/groovy/com/netflix/nebula/lint/plugin/GradleLintPlugin.groovy
@@ -105,9 +105,9 @@ class GradleLintPlugin implements Plugin<Project> {
 
                             @Override
                             void afterExecute(Task task, TaskState taskState) {
-                                if((taskState.failure && lintExt.autoLintAfterFailure) || task.name == lastTask.name) {
+                                if((taskState.failure && lintExt.autoLintAfterFailure) || (task.name == lastTask.name && !taskState.failure)) {
                                     autoLintTask.lint()
-                                }
+                                } 
                             }
                         })
                     }

--- a/src/main/groovy/com/netflix/nebula/lint/plugin/GradleLintPlugin.groovy
+++ b/src/main/groovy/com/netflix/nebula/lint/plugin/GradleLintPlugin.groovy
@@ -105,7 +105,9 @@ class GradleLintPlugin implements Plugin<Project> {
 
                             @Override
                             void afterExecute(Task task, TaskState taskState) {
-                                if (task.name == lastTask.name && !taskState.failure) {
+                                if(taskState.failure) {
+                                    autoLintTask.lint()
+                                } else if (task.name == lastTask.name) {
                                     autoLintTask.lint()
                                 }
                             }

--- a/src/main/groovy/com/netflix/nebula/lint/plugin/GradleLintPlugin.groovy
+++ b/src/main/groovy/com/netflix/nebula/lint/plugin/GradleLintPlugin.groovy
@@ -94,9 +94,11 @@ class GradleLintPlugin implements Plugin<Project> {
                         List<Task> allTasks = taskGraph.allTasks
                         if (onlyIf(allTasks)) {
                             LinkedList tasks = taskGraph.executionPlan.executionQueue
-                            if (!tasks.empty) {
-                                Task lastTask = tasks.last?.task
-                                lastTask.finalizedBy(autoLintTask)
+                            Task lastTask = tasks.last?.task
+                            taskGraph.afterTask {
+                                if(it.name == lastTask.name) {
+                                    autoLintTask.lint()
+                                }
                             }
                         }
                     }

--- a/src/main/groovy/com/netflix/nebula/lint/plugin/GradleLintPlugin.groovy
+++ b/src/main/groovy/com/netflix/nebula/lint/plugin/GradleLintPlugin.groovy
@@ -105,9 +105,7 @@ class GradleLintPlugin implements Plugin<Project> {
 
                             @Override
                             void afterExecute(Task task, TaskState taskState) {
-                                if(taskState.failure) {
-                                    autoLintTask.lint()
-                                } else if (task.name == lastTask.name) {
+                                if(taskState.failure || task.name == lastTask.name) {
                                     autoLintTask.lint()
                                 }
                             }

--- a/src/main/groovy/com/netflix/nebula/lint/plugin/GradleLintPlugin.groovy
+++ b/src/main/groovy/com/netflix/nebula/lint/plugin/GradleLintPlugin.groovy
@@ -105,7 +105,7 @@ class GradleLintPlugin implements Plugin<Project> {
 
                             @Override
                             void afterExecute(Task task, TaskState taskState) {
-                                if(taskState.failure || task.name == lastTask.name) {
+                                if((taskState.failure && lintExt.autoLintAfterFailure) || task.name == lastTask.name) {
                                     autoLintTask.lint()
                                 }
                             }


### PR DESCRIPTION
We faced the following when moving to Gradle 5:

```
The configuration :annotationProcessor was resolved without accessing the project in a safe manner.  This may happen when a configuration is resolved from a thread not managed by Gradle or from a different project.  See https://docs.gradle.org/5.0-rc-1/userguide/troubleshooting_dependency_resolution.html#configuration_resolution_constraints for more details. This behaviour has been deprecated and is scheduled to be removed in Gradle 6.0.
``` 

On that time we identified this as the potential issue -> https://github.com/nebula-plugins/gradle-lint-plugin/blob/master/src/main/groovy/com/netflix/nebula/lint/plugin/GradleLintPlugin.groovy#L70

Executing a task explicitly in the `buildFinished` listener.

IIRC, this was because we invoked the task directly after the build was finished. Hopefully this approach doesn't violate things

This is a proposal to use `TaskExecutionListener` and execute lint once we finished our last task or after a failed task (if `autoLintAfterFailure` is on).

Initially, I tried to modify the `taskGraph` as follows:

```
project.gradle.taskGraph.whenReady { taskGraph ->
                        List<Task> allTasks = taskGraph.allTasks
                        LinkedList tasks = taskGraph.executionPlan.executionQueue
                        Task lastTask = tasks.last?.task
                         lastTask.finalizedBy(autoLintTask)
}
```

This didn't work as expected, while `lastTask` had the finalized by:

```
finalizedBy = {DefaultTaskDependency@9305} 
 immutableValues = {RegularImmutableSet@9325}  size = 0
 mutableValues = {DefaultTaskDependency$TaskDependencySet@9326}  size = 1
  0 = {LintGradleTask_Decorated@7795} "task ':autoLintGradle'"
 resolver = {DefaultTaskContainer_Decorated@9327}  size = 34
```

It appears that gradle won't execute tasks that aren't part of the task graph, regardless if we mutate the `finalizedBy` property. Unfortunately, `taskGraph` is immutable so we can't register a new task on it, which makes sense because gradle already evaluated the project.

