### PR TITLE
Remove instantiator private api usage

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -154,3 +154,6 @@ if (GradleVersion.version(project.gradle.gradleVersion).compareTo(GradleVersion.
 compileKotlin.dependsOn compileGroovy
 compileKotlin.classpath += files(compileGroovy.destinationDir)
 classes.dependsOn compileKotlin
+
+targetCompatibility = JavaVersion.VERSION_1_8
+sourceCompatibility = JavaVersion.VERSION_1_8

--- a/src/main/groovy/com/netflix/nebula/lint/plugin/GradleLintReportTask.groovy
+++ b/src/main/groovy/com/netflix/nebula/lint/plugin/GradleLintReportTask.groovy
@@ -32,14 +32,11 @@ import org.gradle.api.reporting.Reporting
 import org.gradle.api.tasks.Nested
 import org.gradle.api.tasks.TaskAction
 import org.gradle.api.tasks.VerificationTask
-import org.gradle.internal.reflect.Instantiator
-import org.gradle.util.DeprecationLogger
 
 import static com.netflix.nebula.lint.StyledTextService.Styling.*
 
-import javax.inject.Inject
-
 class GradleLintReportTask extends DefaultTask implements VerificationTask, Reporting<CodeNarcReports> {
+
     @Nested
     private final CodeNarcReportsImpl reports
 
@@ -50,9 +47,7 @@ class GradleLintReportTask extends DefaultTask implements VerificationTask, Repo
 
     GradleLintReportTask() {
         CodeNarcReportsImpl codeNarcReports
-        DeprecationLogger.whileDisabled() {
-            codeNarcReports = instantiator.newInstance(CodeNarcReportsImpl, this)
-        }
+        codeNarcReports = project.objects.newInstance(CodeNarcReportsImpl.class, this)
         reports = codeNarcReports
         outputs.upToDateWhen { false }
         group = 'lint'
@@ -88,11 +83,6 @@ class GradleLintReportTask extends DefaultTask implements VerificationTask, Repo
             }
         }
 
-    }
-
-    @Inject
-    Instantiator getInstantiator() {
-        null // see http://gradle.1045684.n5.nabble.com/injecting-dependencies-into-task-instances-td5712637.html
     }
 
     /**

--- a/src/test/groovy/com/netflix/nebula/lint/plugin/FixGradleLintTaskSpec.groovy
+++ b/src/test/groovy/com/netflix/nebula/lint/plugin/FixGradleLintTaskSpec.groovy
@@ -175,7 +175,7 @@ dependencies {\r
 
             gradleLint.rules = ['all-dependencies']
             """.stripIndent()
-        gradleVersion = '2.13'
+        gradleVersion = '4.2' //we don't support older versions anymore
 
         when:
         def results = runTasksSuccessfully('assemble', 'lintGradle')


### PR DESCRIPTION
This is to stop using `instantiator` which is deprecated and potentially removed.

Moving to `ObjectFactory` is the right way to do things now 