### PR TITLE
Duplicate META-INF/versions/9/module-info do not cause violations.

### DIFF
--- a/src/main/kotlin/com/netflix/nebula/lint/rule/dependency/DuplicateDependencyService.kt
+++ b/src/main/kotlin/com/netflix/nebula/lint/rule/dependency/DuplicateDependencyService.kt
@@ -29,7 +29,13 @@ class DuplicateDependencyService(val project: Project) {
         val dependencyClasses = dependencyService.jarContents(mvid.module)?.classes ?: return emptyList()
         val dupeDependencyClasses = dependencyService.artifactsByClass(conf)
                 .filter {
-                    !BLACKLISTED_CLASSES.contains(it.key)
+                    var allowable = true
+                    BLACKLISTED_CLASSES.forEach { bc ->
+                        if (it.key.contains(bc)) {
+                            allowable = false
+                        }
+                    }
+                    allowable
                 }
                 .filter {
                     // don't count artifacts that have the same ModuleIdentifier, which are different versions of the same


### PR DESCRIPTION
There has been a check to disregard duplicate classes in "package-info" and "module-info", but now this ensures that the whole classpath (example: `META-INF/versions/9/module-info`) follows this same logic.