### PR TITLE
OverriddenDependencyVersionRule: use proper constructor for DefaultVersionSelectorScheme

### DIFF
--- a/gradle/dependency-locks/compile.lockfile
+++ b/gradle/dependency-locks/compile.lockfile
@@ -2,7 +2,7 @@
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
 com.google.guava:guava:19.0
-com.netflix.nebula:nebula-gradle-interop:1.0.7
+com.netflix.nebula:nebula-gradle-interop:1.0.8
 com.netflix.nebula:nebula-test:7.3.0
 commons-lang:commons-lang:2.6
 javax.inject:javax.inject:1

--- a/gradle/dependency-locks/compileClasspath.lockfile
+++ b/gradle/dependency-locks/compileClasspath.lockfile
@@ -14,7 +14,7 @@ com.jcraft:jsch:0.1.54
 com.jcraft:jzlib:1.1.2
 com.netflix.nebula:gradle-contacts-plugin:4.1.1
 com.netflix.nebula:gradle-info-plugin:5.0.3
-com.netflix.nebula:nebula-gradle-interop:1.0.7
+com.netflix.nebula:nebula-gradle-interop:1.0.8
 com.netflix.nebula:nebula-test:7.3.0
 com.perforce:p4java:2015.2.1365273
 com.trilead:trilead-ssh2:1.0.0-build220

--- a/gradle/dependency-locks/default.lockfile
+++ b/gradle/dependency-locks/default.lockfile
@@ -2,7 +2,7 @@
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
 com.google.guava:guava:19.0
-com.netflix.nebula:nebula-gradle-interop:1.0.7
+com.netflix.nebula:nebula-gradle-interop:1.0.8
 com.netflix.nebula:nebula-test:7.3.0
 commons-lang:commons-lang:2.6
 javax.inject:javax.inject:1

--- a/gradle/dependency-locks/integTestCompile.lockfile
+++ b/gradle/dependency-locks/integTestCompile.lockfile
@@ -15,7 +15,7 @@ com.jcraft:jsch:0.1.54
 com.jcraft:jzlib:1.1.2
 com.netflix.nebula:gradle-contacts-plugin:4.1.1
 com.netflix.nebula:gradle-info-plugin:5.0.3
-com.netflix.nebula:nebula-gradle-interop:1.0.7
+com.netflix.nebula:nebula-gradle-interop:1.0.8
 com.netflix.nebula:nebula-test:7.3.0
 com.perforce:p4java:2015.2.1365273
 com.trilead:trilead-ssh2:1.0.0-build220

--- a/gradle/dependency-locks/integTestCompileClasspath.lockfile
+++ b/gradle/dependency-locks/integTestCompileClasspath.lockfile
@@ -15,7 +15,7 @@ com.jcraft:jsch:0.1.54
 com.jcraft:jzlib:1.1.2
 com.netflix.nebula:gradle-contacts-plugin:4.1.1
 com.netflix.nebula:gradle-info-plugin:5.0.3
-com.netflix.nebula:nebula-gradle-interop:1.0.7
+com.netflix.nebula:nebula-gradle-interop:1.0.8
 com.netflix.nebula:nebula-test:7.3.0
 com.perforce:p4java:2015.2.1365273
 com.trilead:trilead-ssh2:1.0.0-build220

--- a/gradle/dependency-locks/integTestRuntime.lockfile
+++ b/gradle/dependency-locks/integTestRuntime.lockfile
@@ -15,7 +15,7 @@ com.jcraft:jsch:0.1.54
 com.jcraft:jzlib:1.1.2
 com.netflix.nebula:gradle-contacts-plugin:4.1.1
 com.netflix.nebula:gradle-info-plugin:5.0.3
-com.netflix.nebula:nebula-gradle-interop:1.0.7
+com.netflix.nebula:nebula-gradle-interop:1.0.8
 com.netflix.nebula:nebula-test:7.3.0
 com.perforce:p4java:2015.2.1365273
 com.trilead:trilead-ssh2:1.0.0-build220

--- a/gradle/dependency-locks/integTestRuntimeClasspath.lockfile
+++ b/gradle/dependency-locks/integTestRuntimeClasspath.lockfile
@@ -15,7 +15,7 @@ com.jcraft:jsch:0.1.54
 com.jcraft:jzlib:1.1.2
 com.netflix.nebula:gradle-contacts-plugin:4.1.1
 com.netflix.nebula:gradle-info-plugin:5.0.3
-com.netflix.nebula:nebula-gradle-interop:1.0.7
+com.netflix.nebula:nebula-gradle-interop:1.0.8
 com.netflix.nebula:nebula-test:7.3.0
 com.perforce:p4java:2015.2.1365273
 com.trilead:trilead-ssh2:1.0.0-build220

--- a/gradle/dependency-locks/runtime.lockfile
+++ b/gradle/dependency-locks/runtime.lockfile
@@ -2,7 +2,7 @@
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
 com.google.guava:guava:19.0
-com.netflix.nebula:nebula-gradle-interop:1.0.7
+com.netflix.nebula:nebula-gradle-interop:1.0.8
 com.netflix.nebula:nebula-test:7.3.0
 commons-lang:commons-lang:2.6
 javax.inject:javax.inject:1

--- a/gradle/dependency-locks/runtimeClasspath.lockfile
+++ b/gradle/dependency-locks/runtimeClasspath.lockfile
@@ -2,7 +2,7 @@
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
 com.google.guava:guava:19.0
-com.netflix.nebula:nebula-gradle-interop:1.0.7
+com.netflix.nebula:nebula-gradle-interop:1.0.8
 com.netflix.nebula:nebula-test:7.3.0
 commons-lang:commons-lang:2.6
 javax.inject:javax.inject:1

--- a/gradle/dependency-locks/testCompile.lockfile
+++ b/gradle/dependency-locks/testCompile.lockfile
@@ -15,7 +15,7 @@ com.jcraft:jsch:0.1.54
 com.jcraft:jzlib:1.1.2
 com.netflix.nebula:gradle-contacts-plugin:4.1.1
 com.netflix.nebula:gradle-info-plugin:5.0.3
-com.netflix.nebula:nebula-gradle-interop:1.0.7
+com.netflix.nebula:nebula-gradle-interop:1.0.8
 com.netflix.nebula:nebula-test:7.3.0
 com.perforce:p4java:2015.2.1365273
 com.trilead:trilead-ssh2:1.0.0-build220

--- a/gradle/dependency-locks/testCompileClasspath.lockfile
+++ b/gradle/dependency-locks/testCompileClasspath.lockfile
@@ -15,7 +15,7 @@ com.jcraft:jsch:0.1.54
 com.jcraft:jzlib:1.1.2
 com.netflix.nebula:gradle-contacts-plugin:4.1.1
 com.netflix.nebula:gradle-info-plugin:5.0.3
-com.netflix.nebula:nebula-gradle-interop:1.0.7
+com.netflix.nebula:nebula-gradle-interop:1.0.8
 com.netflix.nebula:nebula-test:7.3.0
 com.perforce:p4java:2015.2.1365273
 com.trilead:trilead-ssh2:1.0.0-build220

--- a/gradle/dependency-locks/testRuntime.lockfile
+++ b/gradle/dependency-locks/testRuntime.lockfile
@@ -15,7 +15,7 @@ com.jcraft:jsch:0.1.54
 com.jcraft:jzlib:1.1.2
 com.netflix.nebula:gradle-contacts-plugin:4.1.1
 com.netflix.nebula:gradle-info-plugin:5.0.3
-com.netflix.nebula:nebula-gradle-interop:1.0.7
+com.netflix.nebula:nebula-gradle-interop:1.0.8
 com.netflix.nebula:nebula-test:7.3.0
 com.perforce:p4java:2015.2.1365273
 com.trilead:trilead-ssh2:1.0.0-build220

--- a/gradle/dependency-locks/testRuntimeClasspath.lockfile
+++ b/gradle/dependency-locks/testRuntimeClasspath.lockfile
@@ -15,7 +15,7 @@ com.jcraft:jsch:0.1.54
 com.jcraft:jzlib:1.1.2
 com.netflix.nebula:gradle-contacts-plugin:4.1.1
 com.netflix.nebula:gradle-info-plugin:5.0.3
-com.netflix.nebula:nebula-gradle-interop:1.0.7
+com.netflix.nebula:nebula-gradle-interop:1.0.8
 com.netflix.nebula:nebula-test:7.3.0
 com.perforce:p4java:2015.2.1365273
 com.trilead:trilead-ssh2:1.0.0-build220

--- a/src/main/groovy/com/netflix/nebula/lint/rule/dependency/OverriddenDependencyVersionRule.groovy
+++ b/src/main/groovy/com/netflix/nebula/lint/rule/dependency/OverriddenDependencyVersionRule.groovy
@@ -10,11 +10,12 @@ import org.gradle.api.attributes.AttributeContainer
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.DefaultVersionComparator
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.DefaultVersionSelectorScheme
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.LatestVersionSelector
+import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionParser
 
 class OverriddenDependencyVersionRule extends GradleLintRule implements GradleModelAware {
     String description = 'be declarative about first order dependency versions that are changed by conflict resolution'
 
-    def selectorScheme = new DefaultVersionSelectorScheme(new DefaultVersionComparator())
+    def selectorScheme = new DefaultVersionSelectorScheme(new DefaultVersionComparator(), new VersionParser())
 
     def resolvableAndResolvedConfigurations
 


### PR DESCRIPTION
Related to https://github.com/nebula-plugins/nebula-gradle-interop/issues/5