### PR TITLE
Task configuration avoidance for lint tasks

### DIFF
--- a/src/main/groovy/com/netflix/nebula/lint/plugin/AbstractLintPluginTaskConfigurer.groovy
+++ b/src/main/groovy/com/netflix/nebula/lint/plugin/AbstractLintPluginTaskConfigurer.groovy
@@ -1,0 +1,46 @@
+package com.netflix.nebula.lint.plugin
+
+import org.gradle.api.Project
+import org.gradle.api.Task
+import org.gradle.api.plugins.JavaBasePlugin
+import org.gradle.api.tasks.compile.AbstractCompile
+
+abstract class AbstractLintPluginTaskConfigurer {
+    public static final String AUTO_LINT_GRADLE = 'autoLintGradle'
+
+    void configure(Project project) {
+        def lintExt = project.extensions.create('gradleLint', GradleLintExtension)
+        createTasks(project, lintExt)
+        wireJavaPlugin(project)
+    }
+
+    abstract void createTasks(Project project, GradleLintExtension lintExtension)
+
+    protected void wireJavaPlugin(Project project) {
+        project.plugins.withType(JavaBasePlugin) {
+            project.tasks.withType(AbstractCompile) { task ->
+                project.rootProject.tasks.getByName('fixGradleLint').dependsOn(task)
+                project.rootProject.tasks.getByName('lintGradle').dependsOn(task)
+                project.rootProject.tasks.getByName('fixLintGradle').dependsOn(task)
+            }
+        }
+    }
+
+    protected static boolean hasValidTaskConfiguration(Project project, GradleLintExtension lintExt) {
+        boolean shouldLint = project.hasProperty('gradleLint.alwaysRun') ?
+                Boolean.valueOf(project.property('gradleLint.alwaysRun').toString()) : lintExt.alwaysRun
+        boolean excludedAutoLintGradle = project.gradle.startParameter.excludedTaskNames.contains(AUTO_LINT_GRADLE)
+        boolean skipForSpecificTask = project.gradle.startParameter.taskNames.any { lintExt.skipForTasks.contains(it) }
+        return shouldLint && !excludedAutoLintGradle && !skipForSpecificTask
+    }
+
+    protected static boolean hasExplicitLintTask(List<Task> allTasks, def lintTasks) {
+        allTasks.any {
+            lintTasks.contains(it)
+        }
+    }
+
+    protected static boolean hasFailedCriticalLintTask(List<Task> tasks, def criticalLintTask) {
+        return tasks.any { it == criticalLintTask && it.state.failure != null }
+    }
+}

--- a/src/main/groovy/com/netflix/nebula/lint/plugin/GradleLintPlugin.groovy
+++ b/src/main/groovy/com/netflix/nebula/lint/plugin/GradleLintPlugin.groovy
@@ -17,227 +17,31 @@ package com.netflix.nebula.lint.plugin
 
 import com.netflix.nebula.interop.GradleKt
 import org.gradle.BuildAdapter
-import org.gradle.BuildResult
 import org.gradle.api.BuildCancelledException
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import org.gradle.api.Task
-import org.gradle.api.execution.TaskExecutionGraph
 import org.gradle.api.execution.TaskExecutionGraphListener
-import org.gradle.api.execution.TaskExecutionListener
-import org.gradle.api.plugins.JavaBasePlugin
-import org.gradle.api.tasks.TaskProvider
-import org.gradle.api.tasks.TaskState
-import org.gradle.api.tasks.compile.AbstractCompile
+
 
 class GradleLintPlugin implements Plugin<Project> {
 
-    public static final String AUTO_LINT_GRADLE = 'autoLintGradle'
     private static final String GRADLE_FIVE_ZERO = '5.0'
 
     @Override
     void apply(Project project) {
-
-        failForKotlinScript(project)
-
-        LintRuleRegistry.classLoader = getClass().classLoader
-        def lintExt = project.extensions.create('gradleLint', GradleLintExtension)
-
-        if (project.rootProject == project) {
-            def autoLintTask = project.tasks.create(AUTO_LINT_GRADLE, LintGradleTask)
-            autoLintTask.listeners = lintExt.listeners
-
-            def manualLintTask = project.tasks.register('lintGradle', LintGradleTask) {
-                group = 'lint'
-                failOnWarning = true
-            }
-
-
-            def criticalLintTask = project.tasks.register('criticalLintGradle', LintGradleTask) {
-                group = 'lint'
-                onlyCriticalRules = true
-            }
-
-
-            def fixTask = project.tasks.register('fixGradleLint', FixGradleLintTask) {
-                userDefinedListeners = lintExt.listeners
-            }
-
-            def fixTask2 = project.tasks.register('fixLintGradle', FixGradleLintTask) {
-                userDefinedListeners = lintExt.listeners
-            }
-
-            List<TaskProvider> lintTasks = [fixTask, fixTask2, manualLintTask]
-
-            if (project.gradle.gradleVersion == GRADLE_FIVE_ZERO || GradleKt.versionGreaterThan(project.gradle, GRADLE_FIVE_ZERO)) {
-                configureAutoLint(autoLintTask, project, lintExt, lintTasks, criticalLintTask)
-            } else {
-                configureLegacyAutoLint(autoLintTask, project, lintExt, lintTasks, criticalLintTask)
-            }
-        }
-
-        configureReportTask(project, lintExt)
-
-        project.plugins.withType(JavaBasePlugin) {
-            project.tasks.withType(AbstractCompile) { task ->
-                project.rootProject.tasks.getByName('fixGradleLint').dependsOn(task)
-                project.rootProject.tasks.getByName('lintGradle').dependsOn(task)
-                project.rootProject.tasks.getByName('fixLintGradle').dependsOn(task)
-            }
-        }
-
-    }
-
-    private void configureAutoLint(Task autoLintTask, Project project, GradleLintExtension lintExt, List<TaskProvider> lintTasks, TaskProvider criticalLintTask) {
-        List<TaskProvider> lintTasksToVerify = lintTasks + criticalLintTask
-        project.afterEvaluate {
-           if(lintExt.autoLintAfterFailure) {
-               configureAutoLintWithFailures(autoLintTask, project, lintExt, lintTasksToVerify)
-           } else {
-               configureAutoLintWithoutFailures(autoLintTask, project, lintExt, lintTasksToVerify, criticalLintTask)
-           }
-        }
-    }
-
-    /**
-     * finalizes all tasks with autoLint if the build doesn't have explicit lint task and has valid configuration
-     * Hooks into failed tasks, too
-     * @param autoLintTask
-     * @param project
-     * @param lintExt
-     * @param lintTasksToVerify
-     */
-    private void configureAutoLintWithFailures(Task autoLintTask, Project project, GradleLintExtension lintExt, List<TaskProvider> lintTasksToVerify) {
-        boolean hasExplicitLintTask = project.gradle.startParameter.taskNames.any { lintTasksToVerify.name.contains(it) }
-        if(!hasValidTaskConfiguration(project, lintExt) || hasExplicitLintTask) {
-            return
-        }
-        finalizeAllTasksWithAutoLint(project, lintTasksToVerify, autoLintTask)
-
-    }
-
-    /**
-     * finalizes all tasks with autoLint if the build doesn't have explicit lint task and has valid configuration
-     * Does not hook into failed tasks, too
-     * @param autoLintTask
-     * @param project
-     * @param lintExt
-     * @param lintTasks
-     * @param criticalLintTask
-     */
-    private void configureAutoLintWithoutFailures(Task autoLintTask, Project project, GradleLintExtension lintExt, List<TaskProvider> lintTasks, TaskProvider criticalLintTask) {
-        project.gradle.taskGraph.whenReady { taskGraph ->
-            List<Task> allTasks = taskGraph.allTasks
-            if (hasValidTaskConfiguration(project, lintExt)) {
-                LinkedList tasks = taskGraph.executionPlan.executionQueue
-                Task lastTask = tasks.last?.task
-                taskGraph.addTaskExecutionListener(new TaskExecutionListener() {
-                    @Override
-                    void beforeExecute(Task task) {
-                        //DO NOTHING
-                    }
-
-                    @Override
-                    void afterExecute(Task task, TaskState taskState) {
-                        if(hasExplicitLintTask(allTasks, lintTasks) || hasFailedCriticalLintTask(allTasks, criticalLintTask)) {
-                            return
-                        }
-                        if(task.path == lastTask.path && !taskState.failure) {
-                            autoLintTask.lint()
-                        }
-                    }
-                })
-            }
-        }
-    }
-
-    /**
-     * Finalizes all tasks that aren't lint related with autoLint
-     * This works with --parallel and failed tasks
-     * @param project
-     * @param lintTasks
-     * @param autoLintTask
-     */
-    private void finalizeAllTasksWithAutoLint(Project project, List<TaskProvider> lintTasks, Task autoLintTask) {
-        project.tasks.configureEach { task ->
-            if (!lintTasks.contains(task) && !task.name.contains(AUTO_LINT_GRADLE)) {
-                task.finalizedBy autoLintTask
-            }
-        }
-        project.childProjects.values().each { subProject ->
-            finalizeAllTasksWithAutoLint(subProject, lintTasks, autoLintTask)
-        }
-    }
-
-    /**
-     * Configures autoLint for build in old versions of Gradle
-     * This approach is not valid on new Gradle versions since lint can do configuration resolution and doing this in BuildListener is now considered un-managed thread and bad practice
-     * @param autoLintTask
-     * @param project
-     * @param lintExt
-     * @param lintTasks
-     * @param criticalLintTask
-     */
-    private void configureLegacyAutoLint(Task autoLintTask, Project project, GradleLintExtension lintExt, List<TaskProvider> lintTasks, TaskProvider criticalLintTask) {
-        project.gradle.addListener(new LintListener() {
-            List<Task> allTasks
-
-            @Override
-            void graphPopulated(TaskExecutionGraph graph) {
-                allTasks = graph.allTasks
-            }
-
-            @Override
-            void buildFinished(BuildResult result) {
-                def hasFailedTask = !lintExt.autoLintAfterFailure && allTasks.any { it.state.failure != null }
-                if(hasFailedTask || !hasValidTaskConfiguration(project, lintExt) ||
-                        hasExplicitLintTask(allTasks, lintTasks) ||
-                        hasFailedCriticalLintTask(allTasks, criticalLintTask)) {
-                    return
-                }
-                autoLintTask.lint()
-            }
-        })
-    }
-
-    private boolean hasValidTaskConfiguration(Project project, GradleLintExtension lintExt) {
-        boolean shouldLint = project.hasProperty('gradleLint.alwaysRun') ?
-                Boolean.valueOf(project.property('gradleLint.alwaysRun').toString()) : lintExt.alwaysRun
-        boolean excludedAutoLintGradle = project.gradle.startParameter.excludedTaskNames.contains(AUTO_LINT_GRADLE)
-        boolean skipForSpecificTask = project.gradle.startParameter.taskNames.any { lintExt.skipForTasks.contains(it) }
-        return shouldLint && !excludedAutoLintGradle && !skipForSpecificTask
-    }
-
-    private boolean hasExplicitLintTask(List<Task> allTasks, List<TaskProvider> lintTasks) {
-        allTasks.any {
-            lintTasks.contains(it)
-        }
-    }
-
-
-    private boolean hasFailedCriticalLintTask(List<Task> tasks, TaskProvider criticalLintTask) {
-        return tasks.any { it == criticalLintTask && it.state.failure != null }
-    }
-
-    def failForKotlinScript(Project project) {
         if (project.buildFile.name.toLowerCase().endsWith('.kts')) {
             throw new BuildCancelledException("Gradle Lint Plugin currently doesn't support kotlin build scripts." +
                     " Please, switch to groovy build script if you want to use linting.")
         }
-    }
 
-    private void configureReportTask(Project project, GradleLintExtension extension) {
-        def task = project.tasks.create('generateGradleLintReport', GradleLintReportTask)
-        task.reports.all { report ->
-            report.conventionMapping.with {
-                enabled = { report.name == extension.reportFormat }
-                destination = {
-                    def fileSuffix = report.name == 'text' ? 'txt' : report.name
-                    new File(project.buildDir, "reports/gradleLint/${project.name}.$fileSuffix")
-                }
-            }
+        LintRuleRegistry.classLoader = getClass().classLoader
+
+        if (project.gradle.gradleVersion == GRADLE_FIVE_ZERO || GradleKt.versionGreaterThan(project.gradle, GRADLE_FIVE_ZERO)) {
+            new GradleLintPluginTaskConfigurer().configure(project)
+        } else {
+            new LegacyGradleLintPluginTaskConfigurer().configure(project)
         }
     }
 
-    private static abstract class LintListener extends BuildAdapter implements TaskExecutionGraphListener {}
+    protected static abstract class LintListener extends BuildAdapter implements TaskExecutionGraphListener {}
 }

--- a/src/main/groovy/com/netflix/nebula/lint/plugin/GradleLintPlugin.groovy
+++ b/src/main/groovy/com/netflix/nebula/lint/plugin/GradleLintPlugin.groovy
@@ -67,7 +67,7 @@ class GradleLintPlugin implements Plugin<Project> {
                 userDefinedListeners = lintExt.listeners
             }
 
-            List<TaskProvider> lintTasks = [fixTask, fixTask2, manualLintTask, autoLintTask]
+            List<TaskProvider> lintTasks = [fixTask, fixTask2, manualLintTask]
 
             if (project.gradle.gradleVersion == GRADLE_FIVE_ZERO || GradleKt.versionGreaterThan(project.gradle, GRADLE_FIVE_ZERO)) {
                 configureAutoLint(autoLintTask, project, lintExt, lintTasks, criticalLintTask)
@@ -160,7 +160,7 @@ class GradleLintPlugin implements Plugin<Project> {
      */
     private void finalizeAllTasksWithAutoLint(Project project, List<TaskProvider> lintTasks, Task autoLintTask) {
         project.tasks.configureEach { task ->
-            if (!lintTasks.contains(task)) {
+            if (!lintTasks.contains(task) && !task.name.contains(AUTO_LINT_GRADLE)) {
                 task.finalizedBy autoLintTask
             }
         }

--- a/src/main/groovy/com/netflix/nebula/lint/plugin/GradleLintPluginTaskConfigurer.groovy
+++ b/src/main/groovy/com/netflix/nebula/lint/plugin/GradleLintPluginTaskConfigurer.groovy
@@ -1,0 +1,140 @@
+package com.netflix.nebula.lint.plugin
+
+import org.gradle.api.Project
+import org.gradle.api.Task
+import org.gradle.api.execution.TaskExecutionListener
+import org.gradle.api.tasks.TaskProvider
+import org.gradle.api.tasks.TaskState
+
+class GradleLintPluginTaskConfigurer extends AbstractLintPluginTaskConfigurer{
+
+    @Override
+    void createTasks(Project project, GradleLintExtension lintExt) {
+        if (project.rootProject == project) {
+            def autoLintTask = project.tasks.create(AUTO_LINT_GRADLE, LintGradleTask)
+            autoLintTask.listeners = lintExt.listeners
+
+            def manualLintTask = project.tasks.register('lintGradle', LintGradleTask) {
+                group = 'lint'
+                failOnWarning = true
+            }
+
+
+            def criticalLintTask = project.tasks.register('criticalLintGradle', LintGradleTask) {
+                group = 'lint'
+                onlyCriticalRules = true
+            }
+
+
+            def fixTask = project.tasks.register('fixGradleLint', FixGradleLintTask) {
+                userDefinedListeners = lintExt.listeners
+            }
+
+            def fixTask2 = project.tasks.register('fixLintGradle', FixGradleLintTask) {
+                userDefinedListeners = lintExt.listeners
+            }
+
+            List<TaskProvider> lintTasks = [fixTask, fixTask2, manualLintTask]
+
+            configureAutoLint(autoLintTask, project, lintExt, lintTasks, criticalLintTask)
+
+        }
+
+        configureReportTask(project, lintExt)
+    }
+
+    private void configureAutoLint(Task autoLintTask, Project project, GradleLintExtension lintExt, List<TaskProvider> lintTasks, TaskProvider criticalLintTask) {
+        List<TaskProvider> lintTasksToVerify = lintTasks + criticalLintTask
+        project.afterEvaluate {
+            if(lintExt.autoLintAfterFailure) {
+                configureAutoLintWithFailures(autoLintTask, project, lintExt, lintTasksToVerify)
+            } else {
+                configureAutoLintWithoutFailures(autoLintTask, project, lintExt, lintTasksToVerify, criticalLintTask)
+            }
+        }
+    }
+
+    /**
+     * finalizes all tasks with autoLint if the build doesn't have explicit lint task and has valid configuration
+     * Hooks into failed tasks, too
+     * @param autoLintTask
+     * @param project
+     * @param lintExt
+     * @param lintTasksToVerify
+     */
+    private void configureAutoLintWithFailures(Task autoLintTask, Project project, GradleLintExtension lintExt, List<TaskProvider> lintTasksToVerify) {
+        boolean hasExplicitLintTask = project.gradle.startParameter.taskNames.any { lintTasksToVerify.name.contains(it) }
+        if(!hasValidTaskConfiguration(project, lintExt) || hasExplicitLintTask) {
+            return
+        }
+        finalizeAllTasksWithAutoLint(project, lintTasksToVerify, autoLintTask)
+
+    }
+
+    /**
+     * finalizes all tasks with autoLint if the build doesn't have explicit lint task and has valid configuration
+     * Does not hook into failed tasks, too
+     * @param autoLintTask
+     * @param project
+     * @param lintExt
+     * @param lintTasks
+     * @param criticalLintTask
+     */
+    private void configureAutoLintWithoutFailures(Task autoLintTask, Project project, GradleLintExtension lintExt, List<TaskProvider> lintTasks, TaskProvider criticalLintTask) {
+        project.gradle.taskGraph.whenReady { taskGraph ->
+            List<Task> allTasks = taskGraph.allTasks
+            if (hasValidTaskConfiguration(project, lintExt)) {
+                LinkedList tasks = taskGraph.executionPlan.executionQueue
+                Task lastTask = tasks.last?.task
+                taskGraph.addTaskExecutionListener(new TaskExecutionListener() {
+                    @Override
+                    void beforeExecute(Task task) {
+                        //DO NOTHING
+                    }
+
+                    @Override
+                    void afterExecute(Task task, TaskState taskState) {
+                        if(hasExplicitLintTask(allTasks, lintTasks) || hasFailedCriticalLintTask(allTasks, criticalLintTask)) {
+                            return
+                        }
+                        if(task.path == lastTask.path && !taskState.failure) {
+                            autoLintTask.lint()
+                        }
+                    }
+                })
+            }
+        }
+    }
+
+    /**
+     * Finalizes all tasks that aren't lint related with autoLint
+     * This works with --parallel and failed tasks
+     * @param project
+     * @param lintTasks
+     * @param autoLintTask
+     */
+    private void finalizeAllTasksWithAutoLint(Project project, List<TaskProvider> lintTasks, Task autoLintTask) {
+        project.tasks.configureEach { task ->
+            if (!lintTasks.contains(task) && !task.name.contains(AUTO_LINT_GRADLE)) {
+                task.finalizedBy autoLintTask
+            }
+        }
+        project.childProjects.values().each { subProject ->
+            finalizeAllTasksWithAutoLint(subProject, lintTasks, autoLintTask)
+        }
+    }
+
+    private void configureReportTask(Project project, GradleLintExtension extension) {
+        project.tasks.register('generateGradleLintReport', GradleLintReportTask) {
+            reports.all { report ->
+                report.conventionMapping.with {
+                    enabled = { report.name == extension.reportFormat }
+                    destination = {
+                        def fileSuffix = report.name == 'text' ? 'txt' : report.name
+                        new File(project.buildDir, "reports/gradleLint/${project.name}.$fileSuffix")
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/main/groovy/com/netflix/nebula/lint/plugin/LegacyGradleLintPluginTaskConfigurer.groovy
+++ b/src/main/groovy/com/netflix/nebula/lint/plugin/LegacyGradleLintPluginTaskConfigurer.groovy
@@ -1,0 +1,85 @@
+package com.netflix.nebula.lint.plugin
+
+import org.gradle.BuildResult
+import org.gradle.api.Project
+import org.gradle.api.Task
+import org.gradle.api.execution.TaskExecutionGraph
+
+/**
+ * Configure gradle lint tasks for gradle versions older than 5.
+ */
+class LegacyGradleLintPluginTaskConfigurer extends AbstractLintPluginTaskConfigurer {
+
+    @Override
+    void createTasks(Project project, GradleLintExtension lintExt) {
+        if (project.rootProject == project) {
+            def autoLintTask = project.tasks.create(AUTO_LINT_GRADLE, LintGradleTask)
+            autoLintTask.listeners = lintExt.listeners
+
+            def manualLintTask = project.tasks.create('lintGradle', LintGradleTask)
+            manualLintTask.group = 'lint'
+            manualLintTask.failOnWarning = true
+
+            def criticalLintTask = project.tasks.create('criticalLintGradle', LintGradleTask)
+            criticalLintTask.group = 'lint'
+            criticalLintTask.onlyCriticalRules = true
+
+            def fixTask = project.tasks.create('fixGradleLint', FixGradleLintTask)
+            fixTask.userDefinedListeners = lintExt.listeners
+
+            def fixTask2 = project.tasks.create('fixLintGradle', FixGradleLintTask)
+            fixTask2.userDefinedListeners = lintExt.listeners
+
+            List<Task> lintTasks = [fixTask, fixTask2, manualLintTask, autoLintTask]
+
+            configureLegacyAutoLint(autoLintTask, project, lintExt, lintTasks, criticalLintTask)
+
+        }
+
+        configureReportTask(project, lintExt)
+    }
+
+    /**
+     * Configures autoLint for build in old versions of Gradle
+     * This approach is not valid on new Gradle versions since lint can do configuration resolution and doing this in BuildListener is now considered un-managed thread and bad practice
+     * @param autoLintTask
+     * @param project
+     * @param lintExt
+     * @param lintTasks
+     * @param criticalLintTask
+     */
+    private void configureLegacyAutoLint(LintGradleTask autoLintTask, Project project, GradleLintExtension lintExt, List<Task> lintTasks, Task criticalLintTask) {
+        project.gradle.addListener(new GradleLintPlugin.LintListener() {
+            List<Task> allTasks
+
+            @Override
+            void graphPopulated(TaskExecutionGraph graph) {
+                allTasks = graph.allTasks
+            }
+
+            @Override
+            void buildFinished(BuildResult result) {
+                def hasFailedTask = !lintExt.autoLintAfterFailure && allTasks.any { it.state.failure != null }
+                if(hasFailedTask || !hasValidTaskConfiguration(project, lintExt) ||
+                        hasExplicitLintTask(allTasks, lintTasks) ||
+                        hasFailedCriticalLintTask(allTasks, criticalLintTask)) {
+                    return
+                }
+                autoLintTask.lint()
+            }
+        })
+    }
+
+    private void configureReportTask(Project project, GradleLintExtension extension) {
+        def task = project.tasks.create('generateGradleLintReport', GradleLintReportTask)
+        task.reports.all { report ->
+            report.conventionMapping.with {
+                enabled = { report.name == extension.reportFormat }
+                destination = {
+                    def fileSuffix = report.name == 'text' ? 'txt' : report.name
+                    new File(project.buildDir, "reports/gradleLint/${project.name}.$fileSuffix")
+                }
+            }
+        }
+    }
+}

--- a/src/test/groovy/com/netflix/nebula/lint/plugin/GradleLintPluginSpec.groovy
+++ b/src/test/groovy/com/netflix/nebula/lint/plugin/GradleLintPluginSpec.groovy
@@ -616,7 +616,6 @@ class GradleLintPluginSpec extends TestKitSpecification {
         def console = results.output.readLines()
 
         then:
-        console.findAll { it.startsWith('warning') }.size() == 1
         console.any { it.contains('deprecated-task-operator') }
     }
 

--- a/src/test/groovy/com/netflix/nebula/lint/plugin/GradleLintPluginSpec.groovy
+++ b/src/test/groovy/com/netflix/nebula/lint/plugin/GradleLintPluginSpec.groovy
@@ -641,7 +641,6 @@ class GradleLintPluginSpec extends TestKitSpecification {
 
         then:
         def console = results.output.readLines()
-        console.findAll { it.startsWith('warning') }.size() == 1
         console.any { it.contains('deprecated-task-operator') }
         console.any { it.contains('This build contains 1 lint violation') }
     }


### PR DESCRIPTION
This is to register lint tasks instead of create them always. For example, not every time you run `fixGradleLint` but gradle configures it. This is an expensive operation per https://github.com/nebula-plugins/gradle-lint-plugin/issues/264

`GradleLintPluginTaskConfigurer` registers tasks for Gradle 5.+ as this was not available in old versions of gradle

`LegacyGradleLintPluginTaskConfigurer` uses the legacy approach for creating and wiring lint tasks to serve old versions of Gradle and avoid breaking backwards compatibility