### PR TITLE
DependencyService uses a better way to determine the resolvable configurations from declared configurations

### DIFF
--- a/src/main/groovy/com/netflix/nebula/lint/rule/dependency/AbstractDuplicateDependencyClassRule.groovy
+++ b/src/main/groovy/com/netflix/nebula/lint/rule/dependency/AbstractDuplicateDependencyClassRule.groovy
@@ -51,7 +51,7 @@ abstract class AbstractDuplicateDependencyClassRule extends GradleLintRule imple
     @Override
     protected void visitClassComplete(ClassNode node) {
         for (Configuration conf : directlyUsedConfigurations) {
-            String resolvableConfigurationName = DependencyService.declaredToResolvableConfigurations.get(conf.name) ?: dependencyService.findResolvableConfiguration(conf.name)?.name
+            String resolvableConfigurationName = dependencyService.findAndReplaceNonResolvableConfiguration(conf).name
             if(!resolvableConfigurationName) {
                 continue
             }


### PR DESCRIPTION
`findAndReplaceNonResolvableConfiguration(Configuration config)` returns the original config when the resolution alternative is unclear