### PR TITLE
DependencyService: getResolutionAlternatives should be a List<String>

### DIFF
--- a/src/main/groovy/com/netflix/nebula/lint/rule/dependency/DependencyService.groovy
+++ b/src/main/groovy/com/netflix/nebula/lint/rule/dependency/DependencyService.groovy
@@ -576,7 +576,7 @@ class DependencyService {
         def method = configuration.metaClass.getMetaMethod('getResolutionAlternatives')
         if (method != null) {
             def alternatives = configuration.getResolutionAlternatives()
-            if (alternatives != null && alternatives.size > 0) {
+            if (alternatives != null && alternatives instanceof List<String> && alternatives.size() > 0) {
                 return true
             }
         }


### PR DESCRIPTION
This should always be a `List<String>` 