### PR TITLE
Prevent null pointer exception when parent is null

### DIFF
--- a/src/main/groovy/com/netflix/nebula/lint/rule/dependency/DependencyService.groovy
+++ b/src/main/groovy/com/netflix/nebula/lint/rule/dependency/DependencyService.groovy
@@ -95,9 +95,12 @@ class DependencyService {
                 return terminalConf.resolvedConfiguration.resolvedArtifacts
             } else {
                 Configuration parent = terminalConf.extendsFrom.find { isResolvable(it) }
-                return findAndReplaceDeprecatedConfiguration(parent).resolvedConfiguration.resolvedArtifacts
+                if (parent) {
+                    return findAndReplaceDeprecatedConfiguration(parent).resolvedConfiguration.resolvedArtifacts                    
+                }
+
             }
-        }.flatten()
+        }.flatten().grep()
 
         GParsPool.withPool {
             artifactsToScan


### PR DESCRIPTION
in the case of some non-resolvable dependencies the `parent` is `null` causing `NullPointerException` in `findAndReplaceDeprecatedConfiguration` method.