### PR TITLE
DependencyService: fix sourceSetOutput throwing no-such-method

### DIFF
--- a/src/main/groovy/com/netflix/nebula/lint/rule/dependency/DependencyService.groovy
+++ b/src/main/groovy/com/netflix/nebula/lint/rule/dependency/DependencyService.groovy
@@ -652,7 +652,7 @@ class DependencyService {
         }
 
         // all android confs get squashed into either debug or release output dir?
-        if (conf.startsWith('test')) {
+        if (confName.startsWith('test')) {
             def androidTestDebugOutput = project.tasks.findByName('compileDebugUnitTestJavaWithJavac')?.destinationDir
             if (androidTestDebugOutput && androidTestDebugOutput.exists()) {
                 return androidTestDebugOutput

--- a/src/test/groovy/com/netflix/nebula/lint/rule/dependency/DependencyServiceSpec.groovy
+++ b/src/test/groovy/com/netflix/nebula/lint/rule/dependency/DependencyServiceSpec.groovy
@@ -213,6 +213,7 @@ class DependencyServiceSpec extends IntegrationTestKitSpec {
         """
 
         when:
+        System.setProperty("ignoreDeprecations", "true")
         def results = runTasks('compileClasspathSourceSetOutput')
         def dir = results.output.readLines().find { it.startsWith('@@') }.substring(2)
 


### PR DESCRIPTION
When sourceSet is null

Refactor typo was introduced when the method arg was renamed as part of dealing with resolvable vs non-resolvable configurations.