### PR TITLE
Fix the Gradle Plugin Portal badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Gradle Lint Plugin
 
 ![Support Status](https://img.shields.io/badge/nebula-active-green.svg)
-[![Gradle Plugin Portal](https://img.shields.io/maven-metadata/v/https/plugins.gradle.org/m2/com.netflix.nebula/gradle-lint-plugin/maven-metadata.xml.svg?label=gradlePluginPortal)](https://plugins.gradle.org/plugin/nebula.lint)
+[![Gradle Plugin Portal](https://img.shields.io/gradle-plugin-portal/v/nebula.lint?logo=gradle&label=Gradle%20Plugin%20Portal)](https://plugins.gradle.org/plugin/nebula.lint)
 [![Maven Central](https://img.shields.io/maven-central/v/com.netflix.nebula/gradle-lint-plugin)](https://maven-badges.herokuapp.com/maven-central/com.netflix.nebula/gradle-lint-plugin)
 ![Build](https://github.com/nebula-plugins/gradle-lint-plugin/actions/workflows/nebula.yml/badge.svg)
 [![Apache 2.0](https://img.shields.io/github/license/nebula-plugins/gradle-lint-plugin.svg)](http://www.apache.org/licenses/LICENSE-2.0)


### PR DESCRIPTION
the current README.md contains a a wrong verison number for the gradle plugin portal in its badge:

![image](https://user-images.githubusercontent.com/172195/182781086-efede945-c2e7-47bd-ad38-24af2f34c9e4.png)

this PR fixes this by using a slightly different url from imgshield