### PR TITLE
Fix false positive unused-dependency warning by scanning Annotations with arrays

### DIFF
--- a/src/main/groovy/com/netflix/nebula/lint/rule/dependency/DependencyClassVisitor.groovy
+++ b/src/main/groovy/com/netflix/nebula/lint/rule/dependency/DependencyClassVisitor.groovy
@@ -272,5 +272,7 @@ final class DependencyClassVisitor extends ClassVisitor {
         void visitEnum(String name, String desc, String value) {
             readType(desc)
         }
+
+        @Override AnnotationVisitor visitArray(String name) { this }
     }
 }


### PR DESCRIPTION
This fixes #120, returns the instance of `DependencyClassVisitor` when ASM detects an array. As a result, `visit` is called against each element of the array, subsequently calling `readType` to determine the type and then `readObjectName` to determine which package the class originates from.