### PR TITLE
GradleLintPluginTaskConfigurer: criticalLintGradle should depend on AbstractCompile tasks, similar to other lint tasks

### DIFF
--- a/src/main/groovy/com/netflix/nebula/lint/plugin/GradleLintPluginTaskConfigurer.groovy
+++ b/src/main/groovy/com/netflix/nebula/lint/plugin/GradleLintPluginTaskConfigurer.groovy
@@ -115,6 +115,12 @@ class GradleLintPluginTaskConfigurer extends AbstractLintPluginTaskConfigurer {
                     fixLintGradleTask.dependsOn(project.tasks.withType(AbstractCompile))
                 }
             })
+            project.rootProject.tasks.named(CRITICAL_LINT_GRADLE).configure(new Action<Task>() {
+                @Override
+                void execute(Task criticalLintGradle) {
+                    criticalLintGradle.dependsOn(project.tasks.withType(AbstractCompile))
+                }
+            })
         }
     }
 


### PR DESCRIPTION
There are scenarios where critical lints might require dependency resolution or classes outcome. 

This make sure that it depends on `AbstractCompile`, similar to other tasks 