### PR TITLE
generateGradleLintReport task only in root

### DIFF
--- a/src/main/groovy/com/netflix/nebula/lint/plugin/GradleLintPluginTaskConfigurer.groovy
+++ b/src/main/groovy/com/netflix/nebula/lint/plugin/GradleLintPluginTaskConfigurer.groovy
@@ -89,10 +89,8 @@ class GradleLintPluginTaskConfigurer extends AbstractLintPluginTaskConfigurer {
             List<TaskProvider> lintTasks = [fixTask, fixTask2, manualLintTask]
 
             configureAutoLint(autoLintTask, project, lintExt, lintTasks, criticalLintTask)
-
+            configureReportTask(project, lintExt)
         }
-
-        configureReportTask(project, lintExt)
     }
 
     @Override


### PR DESCRIPTION
Gradle can execute generateGradleLintReport intermixed with fixGradleLint in some cases. That makes the tasks after fixGradleLint see inconsistent state. The lint errors in memory still reference previous build file state but build file was already fixed and the lines and colums in errors can point to wrong places