### PR TITLE
Provide more insight when a lint rule fails to apply successfully

### DIFF
--- a/src/main/groovy/com/netflix/nebula/lint/plugin/UnexpectedLintRuleFailureException.groovy
+++ b/src/main/groovy/com/netflix/nebula/lint/plugin/UnexpectedLintRuleFailureException.groovy
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2015-2025 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.nebula.lint.plugin
+
+import org.gradle.api.GradleException
+
+/**
+ * Thrown when a rule is found to be invalid for some reason when the rule is applied.
+ */
+class UnexpectedLintRuleFailureException extends GradleException {
+
+    UnexpectedLintRuleFailureException(String message) {
+        super(message)
+    }
+
+    UnexpectedLintRuleFailureException(String message, Throwable cause) {
+        super(message, cause)
+    }
+}

--- a/src/test/groovy/com/netflix/nebula/lint/rule/LintRuleApplicationFailureContextSpec.groovy
+++ b/src/test/groovy/com/netflix/nebula/lint/rule/LintRuleApplicationFailureContextSpec.groovy
@@ -1,0 +1,77 @@
+package com.netflix.nebula.lint.rule
+
+import nebula.test.IntegrationSpec
+import org.codehaus.groovy.ast.expr.MethodCallExpression
+import org.gradle.api.logging.LogLevel
+
+class LintRuleApplicationFailureContextSpec extends IntegrationSpec {
+    def setup() {
+        def lintRuleDirectory = new File(projectDir, 'src/main/resources/META-INF/lint-rules')
+        lintRuleDirectory.mkdirs()
+
+        buildFile << """
+            plugins {
+                id 'java-library'
+            }
+            apply plugin: 'nebula.lint'
+            repositories {
+                mavenCentral()
+            }
+            dependencies {
+                implementation('commons-lang:commons-lang:2.6')
+            }
+            """.stripIndent()
+
+        logLevel = LogLevel.LIFECYCLE
+    }
+
+    def 'lint rule application failure with extra context'() {
+        given:
+        buildFile << """
+            gradleLint.rules = ['test-fails-to-apply-successfully-with-extra-context']
+            """.stripIndent()
+
+        when:
+        def results = runTasksWithFailure('fixGradleLint')
+
+        then:
+        results.standardError.contains("Error processing rule Lint Rule 'test-fails-to-apply-successfully-with-extra-context'. " +
+                "Here is some extra context about what to do when you see this unexpected failure")
+    }
+
+    def 'default lint rule application failure messaging'() {
+        given:
+        buildFile << """
+            gradleLint.rules = ['test-fails-to-apply-successfully']
+            """.stripIndent()
+
+        when:
+        def results = runTasksWithFailure('fixGradleLint')
+
+        then:
+        results.standardError.contains("Error processing rule Lint Rule 'test-fails-to-apply-successfully'\n")
+    }
+}
+
+class ExampleRuleWhichFailsToApplySuccessfully extends AbstractModelAwareExampleGradleLintRule {
+    String description = 'example rule that fails to apply successfully with no extra context'
+
+    @Override
+    void visitAnyGradleDependency(MethodCallExpression call, String conf, GradleDependency dep) {
+        throw new RuntimeException("testing when something goes wrong")
+    }
+}
+
+class ExampleRuleWhichFailsToApplySuccessfullyWithExtraContext extends AbstractModelAwareExampleGradleLintRule {
+    String description = 'example rule that fails to apply successfully with some extra context'
+
+    @Override
+    protected String ruleFailureContext() {
+        return "Here is some extra context about what to do when you see this unexpected failure"
+    }
+
+    @Override
+    void visitAnyGradleDependency(MethodCallExpression call, String conf, GradleDependency dep) {
+        throw new RuntimeException("testing when something goes wrong")
+    }
+}

--- a/src/test/resources/META-INF/lint-rules/test-fails-to-apply-successfully-with-extra-context.properties
+++ b/src/test/resources/META-INF/lint-rules/test-fails-to-apply-successfully-with-extra-context.properties
@@ -1,0 +1,1 @@
+implementation-class=com.netflix.nebula.lint.rule.ExampleRuleWhichFailsToApplySuccessfullyWithExtraContext

--- a/src/test/resources/META-INF/lint-rules/test-fails-to-apply-successfully.properties
+++ b/src/test/resources/META-INF/lint-rules/test-fails-to-apply-successfully.properties
@@ -1,0 +1,1 @@
+implementation-class=com.netflix.nebula.lint.rule.ExampleRuleWhichFailsToApplySuccessfully


### PR DESCRIPTION
Also add a hook for a rule to provide more context if it unexpectedly fails to apply