### PR TITLE
add "semi-declarative-buildscript" rule 

### DIFF
--- a/src/main/groovy/com/netflix/nebula/lint/rule/GradleLintRule.groovy
+++ b/src/main/groovy/com/netflix/nebula/lint/rule/GradleLintRule.groovy
@@ -20,7 +20,6 @@ import com.netflix.nebula.lint.GradleViolation
 import com.netflix.nebula.lint.plugin.LintRuleRegistry
 import com.netflix.nebula.lint.plugin.UnexpectedLintRuleFailureException
 import org.codehaus.groovy.ast.ASTNode
-import org.codehaus.groovy.ast.AnnotatedNode
 import org.codehaus.groovy.ast.ClassNode
 import org.codehaus.groovy.ast.expr.*
 import org.codehaus.groovy.ast.stmt.ExpressionStatement

--- a/src/main/groovy/com/netflix/nebula/lint/rule/dsl/SemiDeclarativeRule.groovy
+++ b/src/main/groovy/com/netflix/nebula/lint/rule/dsl/SemiDeclarativeRule.groovy
@@ -1,0 +1,27 @@
+package com.netflix.nebula.lint.rule.dsl
+
+import com.netflix.nebula.lint.rule.ModelAwareGradleLintRule
+import org.codehaus.groovy.ast.ClassNode
+
+/**
+ * This rule will detect non-declarative code within build scripts.
+ * Buildscripts should be as declarative as possible:
+ * Classes needed for buildscripts should be declared in buildSrc or a plugin
+ * "Semi declarative" means we want to be as declarative as possible, even when not using the actual "declarative gradle" feature of Gradle.
+ */
+class SemiDeclarativeRule extends ModelAwareGradleLintRule {
+    @Override
+    String getDescription() {
+        return null
+    }
+
+    @Override
+    void visitClass(ClassNode classNode) {
+        if (classNode.name != "None") {
+            addBuildLintViolation("Don't declare classes in buildscripts. " +
+                    "Try to keep buildscripts declarative. " +
+                    "Declare classes / tasks in buildSrc or a plugin.",
+                    classNode)
+        }
+    }
+}

--- a/src/main/resources/META-INF/lint-rules/semi-declarative-buildscript.properties
+++ b/src/main/resources/META-INF/lint-rules/semi-declarative-buildscript.properties
@@ -1,0 +1,1 @@
+implementation-class=com.netflix.nebula.lint.rule.dsl.SemiDeclarativeRule

--- a/src/test/groovy/com/netflix/nebula/lint/rule/dsl/SemiDeclarativeRuleTest.groovy
+++ b/src/test/groovy/com/netflix/nebula/lint/rule/dsl/SemiDeclarativeRuleTest.groovy
@@ -1,0 +1,24 @@
+package com.netflix.nebula.lint.rule.dsl
+
+import com.netflix.nebula.lint.rule.test.AbstractRuleSpec
+
+class SemiDeclarativeRuleTest extends AbstractRuleSpec {
+    def 'visit class'() {
+        when:
+        project.buildFile << """
+            b = 2
+            a = 1
+            class A {
+                int a
+                A() {
+                    a = 1
+                }
+            }
+        """
+
+        final var results = runRulesAgainst(new SemiDeclarativeRule())
+
+        then:
+        results.violations.size() == 1
+    }
+}


### PR DESCRIPTION
add "semi-declarative-buildscript" rule to help enforce keeping buildscripts as declarative as possible