### PR TITLE
 Fix IllegalResolutionException in UnusedDependencyExcludeRule for Gradle 9.x

### DIFF
--- a/src/test/groovy/com/netflix/nebula/lint/rule/dependency/UnusedDependencyExcludeRuleSpec.groovy
+++ b/src/test/groovy/com/netflix/nebula/lint/rule/dependency/UnusedDependencyExcludeRuleSpec.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 Netflix, Inc.
+ * Copyright 2015-2025 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,7 +28,6 @@ class UnusedDependencyExcludeRuleSpec extends AbstractRuleSpec {
 
     def 'unused exclude violates'() {
         when:
-        // trivial case: no dependencies
         project.buildFile << """
             apply plugin: 'java'
             dependencies {
@@ -58,7 +57,6 @@ class UnusedDependencyExcludeRuleSpec extends AbstractRuleSpec {
 
     def 'unused exclude violates - api configuration'() {
         when:
-        // trivial case: no dependencies
         project.buildFile << """
             apply plugin: 'java-library'
             dependencies {
@@ -89,7 +87,7 @@ class UnusedDependencyExcludeRuleSpec extends AbstractRuleSpec {
 
     def 'exclude matching a transitive dependency does not violate'() {
         when:
-        // trivial case: no dependencies
+
         project.buildFile << """
             apply plugin: 'java'
             dependencies {
@@ -120,7 +118,6 @@ class UnusedDependencyExcludeRuleSpec extends AbstractRuleSpec {
     @Issue('#57')
     def 'exclude on a dependency that is unresolvable is considered unapplicable'() {
         when:
-        // trivial case: no dependencies
         project.buildFile << """
             apply plugin: 'java'
             dependencies {
@@ -146,5 +143,204 @@ class UnusedDependencyExcludeRuleSpec extends AbstractRuleSpec {
 
         then:
         results.violates()
+    }
+
+    def 'detects multiple unused excludes on same dependency'() {
+        when:
+        project.buildFile << """
+            apply plugin: 'java'
+            dependencies {
+                implementation('commons-configuration:commons-configuration:1.10') {
+                    exclude group: 'com.google.guava', module: 'guava'
+                    exclude group: 'com.fasterxml.jackson.core', module: 'jackson-core'
+                    exclude group: 'commons-lang', module: 'commons-lang'
+                }
+            }
+        """
+
+        project.with {
+            apply plugin: 'java'
+            repositories {
+                mavenCentral()
+            }
+            dependencies {
+                implementation('commons-configuration:commons-configuration:1.10') {
+                    exclude group: 'com.google.guava', module: 'guava'
+                    exclude group: 'com.fasterxml.jackson.core', module: 'jackson-core'
+                    exclude group: 'commons-lang', module: 'commons-lang'
+                }
+            }
+        }
+
+        def results = runRulesAgainst(rule)
+
+        then:
+        results.violates()
+
+        results.violations.size() == 2
+        results.violations.any { it.message.contains('the excluded dependency is not a transitive') && it.sourceLine.contains('com.google.guava') }
+        results.violations.any { it.message.contains('the excluded dependency is not a transitive') && it.sourceLine.contains('com.fasterxml.jackson.core') }
+        !results.violations.any { it.sourceLine.contains('commons-lang') && it.sourceLine.contains('commons-lang') }
+    }
+
+    def 'works with testImplementation configuration'() {
+        when:
+        project.buildFile << """
+            apply plugin: 'java'
+            dependencies {
+                testImplementation('junit:junit:4.13.2') {
+                    exclude group: 'fake.group', module: 'fake-module'
+                }
+            }
+        """
+
+        project.with {
+            apply plugin: 'java'
+            repositories {
+                mavenCentral()
+            }
+            dependencies {
+                testImplementation('junit:junit:4.13.2') {
+                    exclude group: 'fake.group', module: 'fake-module'
+                }
+            }
+        }
+
+        def results = runRulesAgainst(rule)
+
+        then:
+        results.violates()
+        results.violations[0].message.contains('the excluded dependency is not a transitive')
+        results.violations[0].sourceLine.contains('fake.group') && results.violations[0].sourceLine.contains('fake-module')
+    }
+
+    def 'handles exclude with only group specified'() {
+        when:
+        project.buildFile << """
+            apply plugin: 'java'
+            dependencies {
+                implementation('commons-configuration:commons-configuration:1.10') {
+                    exclude group: 'com.google.guava'
+                }
+            }
+        """
+
+        project.with {
+            apply plugin: 'java'
+            repositories {
+                mavenCentral()
+            }
+            dependencies {
+                implementation('commons-configuration:commons-configuration:1.10') {
+                    exclude group: 'com.google.guava'
+                }
+            }
+        }
+
+        def results = runRulesAgainst(rule)
+
+        then:
+        results.violates()
+        results.violations[0].message.contains('the excluded dependency is not a transitive')
+    }
+
+    def 'handles exclude with only module specified'() {
+        when:
+        project.buildFile << """
+            apply plugin: 'java'
+            dependencies {
+                implementation('commons-configuration:commons-configuration:1.10') {
+                    exclude module: 'guava'
+                }
+            }
+        """
+
+        project.with {
+            apply plugin: 'java'
+            repositories {
+                mavenCentral()
+            }
+            dependencies {
+                implementation('commons-configuration:commons-configuration:1.10') {
+                    exclude module: 'guava'
+                }
+            }
+        }
+
+        def results = runRulesAgainst(rule)
+
+        then:
+        results.violates()
+        results.violations[0].message.contains('the excluded dependency is not a transitive')
+    }
+
+    @Issue('Gradle 9.x compatibility - detached configurations')
+    def 'rule creates and cleans up configurations properly'() {
+        when:
+        project.buildFile << """
+            apply plugin: 'java'
+            dependencies {
+                implementation('commons-configuration:commons-configuration:1.10') {
+                    exclude group: 'com.google.guava', module: 'guava'
+                }
+            }
+        """
+
+        project.with {
+            apply plugin: 'java'
+            repositories {
+                mavenCentral()
+            }
+            dependencies {
+                implementation('commons-configuration:commons-configuration:1.10') {
+                    exclude group: 'com.google.guava', module: 'guava'
+                }
+            }
+        }
+
+        def configurationsBefore = project.configurations.collect { it.name }
+        def results = runRulesAgainst(rule)
+        def configurationsAfter = project.configurations.collect { it.name }
+
+        then:
+        results.violates()
+        configurationsBefore == configurationsAfter
+        !configurationsAfter.any { it.contains('lintExcludes') }
+    }
+
+    def 'handles complex dependency with multiple transitives'() {
+        when:
+        project.buildFile << """
+            apply plugin: 'java'
+            dependencies {
+                implementation('org.springframework:spring-web:5.3.0') {
+                    exclude group: 'org.springframework', module: 'spring-core' // valid
+                    exclude group: 'fake.spring', module: 'fake-spring-core' // invalid
+                }
+            }
+        """
+
+        project.with {
+            apply plugin: 'java'
+            repositories {
+                mavenCentral()
+            }
+            dependencies {
+                implementation('org.springframework:spring-web:5.3.0') {
+                    exclude group: 'org.springframework', module: 'spring-core'
+                    exclude group: 'fake.spring', module: 'fake-spring-core'
+                }
+            }
+        }
+
+        def results = runRulesAgainst(rule)
+
+        then:
+        results.violates()
+
+        results.violations.size() == 1
+        results.violations[0].message.contains('the excluded dependency is not a transitive')
+        results.violations[0].sourceLine.contains('fake.spring') && results.violations[0].sourceLine.contains('fake-spring-core')
+        !results.violations.any { it.sourceLine.contains('spring-core') && !it.sourceLine.contains('fake') }
     }
 }


### PR DESCRIPTION
Replace project.configurations.create() with detachedConfiguration() and use thread-safe resolutionResult API instead of resolvedConfiguration to avoid  "Resolution of the configuration was attempted without an exclusive lock" errors introduced in Gradle 9.x.