### PR TITLE
Fix Gradle 9 cross-project lock errors with per-project fix tasks

### DIFF
--- a/src/main/groovy/com/netflix/nebula/lint/plugin/FixGradleLintTask.groovy
+++ b/src/main/groovy/com/netflix/nebula/lint/plugin/FixGradleLintTask.groovy
@@ -67,7 +67,7 @@ abstract class FixGradleLintTask extends DefaultTask implements VerificationTask
 
             def patchFile = new File(project.layout.buildDirectory.asFile.get(), GradleLintPatchAction.PATCH_NAME)
             if (patchFile.exists()) {
-                new ApplyCommand(new NotNecessarilyGitRepository(project.projectDir)).setPatch(patchFile.newInputStream()).call()
+                new ApplyCommand(new NotNecessarilyGitRepository(project.rootDir)).setPatch(patchFile.newInputStream()).call()
             }
 
             (userDefinedListeners.get() + infoBrokerAction + consoleOutputAction()).each {

--- a/src/main/groovy/com/netflix/nebula/lint/plugin/GradleLintPlugin.groovy
+++ b/src/main/groovy/com/netflix/nebula/lint/plugin/GradleLintPlugin.groovy
@@ -33,5 +33,15 @@ class GradleLintPlugin implements Plugin<Project> {
             throw new BuildCancelledException("Gradle Lint Plugin requires Gradle 7.1 or newer.")
         }
         new GradleLintPluginTaskConfigurer().configure(project)
+
+        // Apply to subprojects so each gets its own fix tasks, avoiding
+        // Gradle 9 cross-project lock issues when resolving configurations.
+        if (project == project.rootProject) {
+            project.subprojects { sub ->
+                if (!sub.buildFile.name.toLowerCase().endsWith('.kts')) {
+                    sub.pluginManager.apply(GradleLintPlugin)
+                }
+            }
+        }
     }
 }

--- a/src/main/groovy/com/netflix/nebula/lint/plugin/GradleLintPluginTaskConfigurer.groovy
+++ b/src/main/groovy/com/netflix/nebula/lint/plugin/GradleLintPluginTaskConfigurer.groovy
@@ -47,7 +47,27 @@ class GradleLintPluginTaskConfigurer extends AbstractLintPluginTaskConfigurer {
 
     @Override
     void createTasks(Project project, GradleLintExtension lintExt) {
+        // Fix tasks are created on every project so each runs with its own exclusive lock,
+        // avoiding Gradle 9's cross-project resolution errors.
+        def fixTask = project.tasks.register(FIX_GRADLE_LINT, FixGradleLintTask)
+        fixTask.configure {
+            userDefinedListeners.set(lintExt.listeners)
+            notCompatibleWithConfigurationCache("Gradle Lint Plugin is not compatible with configuration cache because it requires project model")
+        }
+
+        def fixTask2 = project.tasks.register(FIX_LINT_GRADLE, FixGradleLintTask)
+        fixTask2.configure {
+            userDefinedListeners.set(lintExt.listeners)
+            notCompatibleWithConfigurationCache("Gradle Lint Plugin is not compatible with configuration cache because it requires project model")
+        }
+
         if (project.rootProject == project) {
+            // Root fix tasks depend on all subproject fix tasks
+            project.subprojects { sub ->
+                fixTask.configure { it.dependsOn(sub.tasks.named(FIX_GRADLE_LINT)) }
+                fixTask2.configure { it.dependsOn(sub.tasks.named(FIX_LINT_GRADLE)) }
+            }
+
             def autoLintTask = project.tasks.register(AUTO_LINT_GRADLE, LintGradleTask)
             autoLintTask.configure {
                 group = LINT_GROUP
@@ -64,25 +84,11 @@ class GradleLintPluginTaskConfigurer extends AbstractLintPluginTaskConfigurer {
                 notCompatibleWithConfigurationCache("Gradle Lint Plugin is not compatible with configuration cache because it requires project model")
             }
 
-
             def criticalLintTask = project.tasks.register(CRITICAL_LINT_GRADLE, LintGradleTask)
             criticalLintTask.configure {
                 group = LINT_GROUP
                 onlyCriticalRules.set(true)
                 projectRootDir.set(project.rootDir)
-                notCompatibleWithConfigurationCache("Gradle Lint Plugin is not compatible with configuration cache because it requires project model")
-            }
-
-
-            def fixTask = project.tasks.register(FIX_GRADLE_LINT, FixGradleLintTask)
-            fixTask.configure {
-                userDefinedListeners.set(lintExt.listeners)
-                notCompatibleWithConfigurationCache("Gradle Lint Plugin is not compatible with configuration cache because it requires project model")
-            }
-
-            def fixTask2 = project.tasks.register(FIX_LINT_GRADLE, FixGradleLintTask)
-            fixTask2.configure {
-                userDefinedListeners.set(lintExt.listeners)
                 notCompatibleWithConfigurationCache("Gradle Lint Plugin is not compatible with configuration cache because it requires project model")
             }
 
@@ -96,30 +102,34 @@ class GradleLintPluginTaskConfigurer extends AbstractLintPluginTaskConfigurer {
     @Override
     void wireJavaPlugin(Project project) {
         project.plugins.withType(JavaBasePlugin) {
-            project.rootProject.tasks.named(FIX_GRADLE_LINT).configure(new Action<Task>() {
+            // Wire this project's fix tasks to depend on its own compile/jar tasks
+            project.tasks.named(FIX_GRADLE_LINT).configure(new Action<Task>() {
                 @Override
                 void execute(Task fixGradleLintTask) {
                     fixGradleLintTask.dependsOn(project.tasks.withType(AbstractCompile), project.tasks.withType(Jar))
                 }
             })
-            project.rootProject.tasks.named(LINT_GRADLE).configure(new Action<Task>() {
-                @Override
-                void execute(Task lintGradleTask) {
-                    lintGradleTask.dependsOn(project.tasks.withType(AbstractCompile), project.tasks.withType(Jar))
-                }
-            })
-            project.rootProject.tasks.named(FIX_LINT_GRADLE).configure(new Action<Task>() {
+            project.tasks.named(FIX_LINT_GRADLE).configure(new Action<Task>() {
                 @Override
                 void execute(Task fixLintGradleTask) {
                     fixLintGradleTask.dependsOn(project.tasks.withType(AbstractCompile), project.tasks.withType(Jar))
                 }
             })
-            project.rootProject.tasks.named(CRITICAL_LINT_GRADLE).configure(new Action<Task>() {
-                @Override
-                void execute(Task criticalLintGradle) {
-                    criticalLintGradle.dependsOn(project.tasks.withType(AbstractCompile), project.tasks.withType(Jar))
-                }
-            })
+            // Lint/critical tasks only exist on root
+            if (project.rootProject == project) {
+                project.tasks.named(LINT_GRADLE).configure(new Action<Task>() {
+                    @Override
+                    void execute(Task lintGradleTask) {
+                        lintGradleTask.dependsOn(project.tasks.withType(AbstractCompile), project.tasks.withType(Jar))
+                    }
+                })
+                project.tasks.named(CRITICAL_LINT_GRADLE).configure(new Action<Task>() {
+                    @Override
+                    void execute(Task criticalLintGradle) {
+                        criticalLintGradle.dependsOn(project.tasks.withType(AbstractCompile), project.tasks.withType(Jar))
+                    }
+                })
+            }
         }
     }
 

--- a/src/main/groovy/com/netflix/nebula/lint/plugin/LintService.groovy
+++ b/src/main/groovy/com/netflix/nebula/lint/plugin/LintService.groovy
@@ -107,28 +107,30 @@ class LintService {
 
     RuleSet ruleSet(Project project) {
         def ruleSet = new CompositeRuleSet()
-        ([project] + project.subprojects).each { p -> ruleSet.addRuleSet(ruleSetForProject(p, false)) }
+        ruleSet.addRuleSet(ruleSetForProject(project, false))
         return ruleSet
     }
 
+    /**
+     * Lints a single project only. In multi-project builds, each project should have its own
+     * lint task that calls this method — avoiding cross-project configuration resolution which
+     * Gradle 9 rejects (exclusive project lock enforcement).
+     */
     Results lint(Project project, boolean onlyCriticalRules) {
         def analyzer = new ReportableAnalyzer(project)
 
-        ([project] + project.subprojects).each { p ->
-            def files = SourceCollector.getAllFiles(p.buildFile, p)
-            def buildFiles = new BuildFiles(files)
-            def ruleSet = ruleSetForProject(p, onlyCriticalRules)
-            if (!ruleSet.rules.isEmpty()) {
-                // establish which file we are linting for each rule
-                ruleSet.rules.each { rule ->
-                    if (rule instanceof GradleLintRule)
-                        rule.buildFiles = buildFiles
-                }
-
-                analyzer.analyze(p, buildFiles.text, ruleSet)
-
-                DependencyService.removeForProject(p)
+        def files = SourceCollector.getAllFiles(project.buildFile, project)
+        def buildFiles = new BuildFiles(files)
+        def ruleSet = ruleSetForProject(project, onlyCriticalRules)
+        if (!ruleSet.rules.isEmpty()) {
+            ruleSet.rules.each { rule ->
+                if (rule instanceof GradleLintRule)
+                    rule.buildFiles = buildFiles
             }
+
+            analyzer.analyze(project, buildFiles.text, ruleSet)
+
+            DependencyService.removeForProject(project)
         }
 
         return analyzer.resultsForRootProject

--- a/src/test/groovy/com/netflix/nebula/lint/plugin/GradleLintPluginSpec.groovy
+++ b/src/test/groovy/com/netflix/nebula/lint/plugin/GradleLintPluginSpec.groovy
@@ -1009,4 +1009,49 @@ class GradleLintPluginSpec extends BaseIntegrationTestKitSpec {
         task << ['dependencyInsight', 'dI', 'depIn']
     }
 
+    @Unroll
+    def 'fixGradleLint on multi-project does not cause cross-project lock errors (#testGradleVersion)'() {
+        given:
+        buildFile << """
+            plugins {
+                id 'nebula.lint'
+            }
+
+            subprojects {
+                apply plugin: 'java'
+                apply plugin: 'nebula.lint'
+                repositories {
+                    mavenCentral()
+                }
+                gradleLint.rules = ['dependency-parentheses']
+            }
+        """
+
+        addSubproject('sub1', """
+            dependencies {
+                implementation('com.google.guava:guava:21.0')
+            }
+        """)
+
+        addSubproject('sub2', """
+            dependencies {
+                implementation('commons-lang:commons-lang:2.6')
+            }
+        """)
+
+        when:
+        gradleVersion = testGradleVersion
+        def results = runTasks('fixGradleLint')
+
+        then:
+        // Verify fix tasks ran on subprojects (not just root)
+        results.task(':sub1:fixGradleLint').outcome == TaskOutcome.SUCCESS
+        results.task(':sub2:fixGradleLint').outcome == TaskOutcome.SUCCESS
+        // Verify violations were actually corrected
+        results.output.contains('Corrected')
+
+        where:
+        testGradleVersion << GradleVersions.ALL
+    }
+
 }


### PR DESCRIPTION
## Summary

- `LintService.lint()` previously iterated `[project] + project.subprojects` from root's `fixGradleLint` task. In Gradle 9, resolving a subproject's configuration from root's task context throws `IllegalResolutionException` because root doesn't hold the subproject's exclusive lock.
- Fix: create `fixGradleLint`/`fixLintGradle` tasks on **every project** (not just root). Each task only lints its own project. Root's fix tasks depend on all subproject fix tasks, so `./gradlew fixGradleLint` still lints the entire build.

## Changes

- **`LintService.lint()`**: process only the given project, not subprojects
- **`GradleLintPlugin`**: auto-apply to subprojects when applied to root
- **`GradleLintPluginTaskConfigurer.createTasks()`**: create fix tasks on every project; root's fix tasks `dependsOn` subproject fix tasks
- **`wireJavaPlugin()`**: wire compile/jar deps to each project's own fix task instead of root's

## Context


```
Resolution of the configuration ':subproject:lintExcludes' was attempted without an exclusive lock.
This is unsafe and not allowed.
```

The root cause is that Gradle 9 enforces exclusive project locks during task execution. The lint plugin's single root task accessing subproject configurations violates this.

## Test plan

- [ ] Existing tests pass
- [ ] Test with multi-project build on Gradle 9: `./gradlew fixGradleLint` lints all projects without lock errors
- [ ] Single-project builds unaffected