### PR TITLE
Fix Gradle 9 cross-project lock errors with per-project lint tasks

### DIFF
--- a/src/main/groovy/com/netflix/nebula/lint/plugin/FixGradleLintTask.groovy
+++ b/src/main/groovy/com/netflix/nebula/lint/plugin/FixGradleLintTask.groovy
@@ -67,7 +67,7 @@ abstract class FixGradleLintTask extends DefaultTask implements VerificationTask
 
             def patchFile = new File(project.layout.buildDirectory.asFile.get(), GradleLintPatchAction.PATCH_NAME)
             if (patchFile.exists()) {
-                new ApplyCommand(new NotNecessarilyGitRepository(project.projectDir)).setPatch(patchFile.newInputStream()).call()
+                new ApplyCommand(new NotNecessarilyGitRepository(project.rootDir)).setPatch(patchFile.newInputStream()).call()
             }
 
             (userDefinedListeners.get() + infoBrokerAction + consoleOutputAction()).each {

--- a/src/main/groovy/com/netflix/nebula/lint/plugin/GradleLintPlugin.groovy
+++ b/src/main/groovy/com/netflix/nebula/lint/plugin/GradleLintPlugin.groovy
@@ -33,5 +33,15 @@ class GradleLintPlugin implements Plugin<Project> {
             throw new BuildCancelledException("Gradle Lint Plugin requires Gradle 7.1 or newer.")
         }
         new GradleLintPluginTaskConfigurer().configure(project)
+
+        if (project == project.rootProject) {
+            project.subprojects { sub ->
+                if (sub.buildFile.name.toLowerCase().endsWith('.kts')) {
+                    project.logger.info("Gradle Lint Plugin skipping subproject '${sub.name}' because it uses a Kotlin build script")
+                } else {
+                    sub.pluginManager.apply(GradleLintPlugin)
+                }
+            }
+        }
     }
 }

--- a/src/main/groovy/com/netflix/nebula/lint/plugin/GradleLintPluginTaskConfigurer.groovy
+++ b/src/main/groovy/com/netflix/nebula/lint/plugin/GradleLintPluginTaskConfigurer.groovy
@@ -47,74 +47,79 @@ class GradleLintPluginTaskConfigurer extends AbstractLintPluginTaskConfigurer {
 
     @Override
     void createTasks(Project project, GradleLintExtension lintExt) {
+        def fixTask = project.tasks.register(FIX_GRADLE_LINT, FixGradleLintTask)
+        fixTask.configure {
+            userDefinedListeners.set(lintExt.listeners)
+            notCompatibleWithConfigurationCache("Gradle Lint Plugin is not compatible with configuration cache because it requires project model")
+        }
+
+        def fixTask2 = project.tasks.register(FIX_LINT_GRADLE, FixGradleLintTask)
+        fixTask2.configure {
+            userDefinedListeners.set(lintExt.listeners)
+            notCompatibleWithConfigurationCache("Gradle Lint Plugin is not compatible with configuration cache because it requires project model")
+        }
+
+        def manualLintTask = project.tasks.register(LINT_GRADLE, LintGradleTask)
+        manualLintTask.configure {
+            group = LINT_GROUP
+            failOnWarning.set(true)
+            projectRootDir.set(project.rootDir)
+            notCompatibleWithConfigurationCache("Gradle Lint Plugin is not compatible with configuration cache because it requires project model")
+        }
+
+        def criticalLintTask = project.tasks.register(CRITICAL_LINT_GRADLE, LintGradleTask)
+        criticalLintTask.configure {
+            group = LINT_GROUP
+            onlyCriticalRules.set(true)
+            projectRootDir.set(project.rootDir)
+            notCompatibleWithConfigurationCache("Gradle Lint Plugin is not compatible with configuration cache because it requires project model")
+        }
+
+        def autoLintTask = project.tasks.register(AUTO_LINT_GRADLE, LintGradleTask)
+        autoLintTask.configure {
+            group = LINT_GROUP
+            listeners = lintExt.listeners
+            projectRootDir.set(project.rootDir)
+            notCompatibleWithConfigurationCache("Gradle Lint Plugin is not compatible with configuration cache because it requires project model")
+        }
+
+        configureReportTask(project, lintExt)
+
         if (project.rootProject == project) {
-            def autoLintTask = project.tasks.register(AUTO_LINT_GRADLE, LintGradleTask)
-            autoLintTask.configure {
-                group = LINT_GROUP
-                listeners = lintExt.listeners
-                projectRootDir.set(project.rootDir)
-                notCompatibleWithConfigurationCache("Gradle Lint Plugin is not compatible with configuration cache because it requires project model")
-            }
-
-            def manualLintTask = project.tasks.register(LINT_GRADLE, LintGradleTask)
-            manualLintTask.configure {
-                group = LINT_GROUP
-                failOnWarning.set(true)
-                projectRootDir.set(project.rootDir)
-                notCompatibleWithConfigurationCache("Gradle Lint Plugin is not compatible with configuration cache because it requires project model")
-            }
-
-
-            def criticalLintTask = project.tasks.register(CRITICAL_LINT_GRADLE, LintGradleTask)
-            criticalLintTask.configure {
-                group = LINT_GROUP
-                onlyCriticalRules.set(true)
-                projectRootDir.set(project.rootDir)
-                notCompatibleWithConfigurationCache("Gradle Lint Plugin is not compatible with configuration cache because it requires project model")
-            }
-
-
-            def fixTask = project.tasks.register(FIX_GRADLE_LINT, FixGradleLintTask)
-            fixTask.configure {
-                userDefinedListeners.set(lintExt.listeners)
-                notCompatibleWithConfigurationCache("Gradle Lint Plugin is not compatible with configuration cache because it requires project model")
-            }
-
-            def fixTask2 = project.tasks.register(FIX_LINT_GRADLE, FixGradleLintTask)
-            fixTask2.configure {
-                userDefinedListeners.set(lintExt.listeners)
-                notCompatibleWithConfigurationCache("Gradle Lint Plugin is not compatible with configuration cache because it requires project model")
+            def allTaskNames = [FIX_GRADLE_LINT, FIX_LINT_GRADLE, LINT_GRADLE, CRITICAL_LINT_GRADLE, AUTO_LINT_GRADLE, GENERATE_GRADLE_LINT_REPORT]
+            project.subprojects { sub ->
+                allTaskNames.each { taskName ->
+                    project.tasks.named(taskName).configure { it.dependsOn(sub.tasks.named(taskName)) }
+                }
             }
 
             List<TaskProvider> lintTasks = [fixTask, fixTask2, manualLintTask]
-
             configureAutoLint(autoLintTask, project, lintExt, lintTasks, criticalLintTask)
-            configureReportTask(project, lintExt)
         }
     }
 
     @Override
     void wireJavaPlugin(Project project) {
         project.plugins.withType(JavaBasePlugin) {
-            project.rootProject.tasks.named(FIX_GRADLE_LINT).configure(new Action<Task>() {
+            project.tasks.named(FIX_GRADLE_LINT).configure(new Action<Task>() {
                 @Override
                 void execute(Task fixGradleLintTask) {
                     fixGradleLintTask.dependsOn(project.tasks.withType(AbstractCompile), project.tasks.withType(Jar))
                 }
             })
-            project.rootProject.tasks.named(LINT_GRADLE).configure(new Action<Task>() {
+            project.tasks.named(LINT_GRADLE).configure(new Action<Task>() {
                 @Override
                 void execute(Task lintGradleTask) {
                     lintGradleTask.dependsOn(project.tasks.withType(AbstractCompile), project.tasks.withType(Jar))
                 }
             })
-            project.rootProject.tasks.named(FIX_LINT_GRADLE).configure(new Action<Task>() {
+            project.tasks.named(FIX_LINT_GRADLE).configure(new Action<Task>() {
                 @Override
                 void execute(Task fixLintGradleTask) {
                     fixLintGradleTask.dependsOn(project.tasks.withType(AbstractCompile), project.tasks.withType(Jar))
                 }
             })
-            project.rootProject.tasks.named(CRITICAL_LINT_GRADLE).configure(new Action<Task>() {
+            project.tasks.named(CRITICAL_LINT_GRADLE).configure(new Action<Task>() {
                 @Override
                 void execute(Task criticalLintGradle) {
                     criticalLintGradle.dependsOn(project.tasks.withType(AbstractCompile), project.tasks.withType(Jar))

--- a/src/main/groovy/com/netflix/nebula/lint/plugin/LintService.groovy
+++ b/src/main/groovy/com/netflix/nebula/lint/plugin/LintService.groovy
@@ -107,28 +107,29 @@ class LintService {
 
     RuleSet ruleSet(Project project) {
         def ruleSet = new CompositeRuleSet()
-        ([project] + project.subprojects).each { p -> ruleSet.addRuleSet(ruleSetForProject(p, false)) }
+        ruleSet.addRuleSet(ruleSetForProject(project, false))
         return ruleSet
     }
 
+    /**
+     * Lints a single project only. In multi-project builds, each project should have its own
+     * lint task that calls this method
+     */
     Results lint(Project project, boolean onlyCriticalRules) {
         def analyzer = new ReportableAnalyzer(project)
 
-        ([project] + project.subprojects).each { p ->
-            def files = SourceCollector.getAllFiles(p.buildFile, p)
-            def buildFiles = new BuildFiles(files)
-            def ruleSet = ruleSetForProject(p, onlyCriticalRules)
-            if (!ruleSet.rules.isEmpty()) {
-                // establish which file we are linting for each rule
-                ruleSet.rules.each { rule ->
-                    if (rule instanceof GradleLintRule)
-                        rule.buildFiles = buildFiles
-                }
-
-                analyzer.analyze(p, buildFiles.text, ruleSet)
-
-                DependencyService.removeForProject(p)
+        def files = SourceCollector.getAllFiles(project.buildFile, project)
+        def buildFiles = new BuildFiles(files)
+        def ruleSet = ruleSetForProject(project, onlyCriticalRules)
+        if (!ruleSet.rules.isEmpty()) {
+            ruleSet.rules.each { rule ->
+                if (rule instanceof GradleLintRule)
+                    rule.buildFiles = buildFiles
             }
+
+            analyzer.analyze(project, buildFiles.text, ruleSet)
+
+            DependencyService.removeForProject(project)
         }
 
         return analyzer.resultsForRootProject

--- a/src/test/groovy/com/netflix/nebula/lint/plugin/GradleLintPluginSpec.groovy
+++ b/src/test/groovy/com/netflix/nebula/lint/plugin/GradleLintPluginSpec.groovy
@@ -1009,4 +1009,40 @@ class GradleLintPluginSpec extends BaseIntegrationTestKitSpec {
         task << ['dependencyInsight', 'dI', 'depIn']
     }
 
+    @Unroll
+    def '#taskName on multi-project does not cause cross-project lock errors (#testGradleVersion)'() {
+        given:
+        buildFile << """
+            plugins {
+                id 'nebula.lint'
+            }
+
+            subprojects {
+                apply plugin: 'java'
+                apply plugin: 'nebula.lint'
+                repositories {
+                    mavenCentral()
+                }
+                gradleLint.criticalRules = ['duplicate-dependency-class']
+                gradleLint.reportFormat = 'text'
+            }
+        """
+
+        addSubproject('sub1', """
+            dependencies {
+                implementation 'com.google.guava:guava:18.0'
+            }
+        """)
+
+        when:
+        gradleVersion = testGradleVersion
+        def results = runTasks(taskName, '--parallel')
+
+        then:
+        !results.output.contains('IllegalResolutionException')
+        !results.output.contains('was attempted without an exclusive lock')
+
+        where:
+        [taskName, testGradleVersion] << [['lintGradle', 'criticalLintGradle', 'fixGradleLint', 'fixLintGradle', 'generateGradleLintReport'], GradleVersions.ALL].combinations()
+    }
 }


### PR DESCRIPTION
## Summary

Fixes #417.

Gradle 9 enforces exclusive project locks — a task on project A cannot resolve configurations belonging to project B. The lint plugin created all lint tasks on the root project only, and `LintService.lint()` iterated subprojects, resolving their configurations from root's task context. This causes `IllegalResolutionException` on multi-project builds with `--parallel`.

This PR makes each project lint only itself:
- All lint tasks are created on every project, not just root
- Root tasks aggregate by depending on subproject tasks
- `LintService.lint()` processes only the given project (no subproject iteration)
- Plugin auto-applies to subprojects when applied to root

### Error before this PR

```
IllegalResolutionException: Resolution of the configuration ':sub1:implementation'
was attempted without an exclusive lock. This is unsafe and not allowed.
```

## Changes

| File | Change |
|------|--------|
| `LintService.groovy` | Remove `([project] + project.subprojects).each` — lint only the given project |
| `GradleLintPlugin.groovy` | Auto-apply to non-`.kts` subprojects when applied to root |
| `GradleLintPluginTaskConfigurer.groovy` | Create all tasks on every project; root aggregates via `dependsOn`. `wireJavaPlugin()`: `project.rootProject.tasks` → `project.tasks` |
| `FixGradleLintTask.groovy` | `project.projectDir` → `project.rootDir` for patch application (paths are relative to root) |

## Test plan

- New parametrized test covers `lintGradle`, `criticalLintGradle`, `fixGradleLint`, `fixLintGradle` across Gradle 9.0.0 and 9.1.0 with `--parallel`
- All 8 new tests fail on `main` with `IllegalResolutionException`, all 8 pass on this branch