### PR TITLE
fix a bug with the full build.gradle file being cleared when block to delete is the last one in the file

### DIFF
--- a/src/main/groovy/com/netflix/nebula/lint/GradleLintPatchAction.groovy
+++ b/src/main/groovy/com/netflix/nebula/lint/GradleLintPatchAction.groovy
@@ -257,7 +257,7 @@ Exception: ${e.getMessage()}
                 ${diffHintsWithMargin(relativePath, patchType, fileMode)}
                 |--- ${patchType == Create ? '/dev/null' : 'a/' + relativePath}
                 |+++ ${patchType == Delete ? '/dev/null' : 'b/' + relativePath}
-                |@@ -${emptyFile ? 0 : firstLineOfContext},$beforeLineCount +${afterLineCount == 0 ? 0 : firstLineOfContext},$afterLineCount @@
+                |@@ -${emptyFile ? 0 : firstLineOfContext},$beforeLineCount +${afterLineCount == 0 && firstLineOfContext == 1 ? 0 : firstLineOfContext},$afterLineCount @@
                 |""".stripMargin()
 
             combinedPatch += diffHeader + patch.join('\n')

--- a/src/test/groovy/com/netflix/nebula/lint/rule/GradleLintPatchActionSpec.groovy
+++ b/src/test/groovy/com/netflix/nebula/lint/rule/GradleLintPatchActionSpec.groovy
@@ -392,6 +392,37 @@ class GradleLintPatchActionSpec extends Specification {
         generator.patch([new GradleLintDeleteLines(violation, f, 1..1)]) == expect
     }
 
+    def 'deleting last lines with no context does not clear the whole file'() {
+        setup:
+        def f = temp.newFile('my.txt')
+        f.text = '''\
+            a
+            b
+            c
+
+
+
+            d
+            e
+            f
+            '''.stripIndent()
+
+        when:
+        def fix = new GradleLintDeleteLines(violation, f, 7..9)
+        def patch = new GradleLintPatchAction(project).patch([fix])
+
+        then:
+        patch == '''
+            diff --git a/my.txt b/my.txt
+            --- a/my.txt
+            +++ b/my.txt
+            @@ -7,3 +7,0 @@
+            -d
+            -e
+            -f
+            '''.substring(1).stripIndent()
+    }
+
     def 'inserting a line'() {
         when:
         def f = temp.newFile('my.txt')


### PR DESCRIPTION
Issue #1: The `GradleLintPatchAction.groovy` generates an invalid patch header for partial end-of-file deletions.                                                                                                                                                                                                                                                                                                              
                                      
When a lint fix deletes lines with no replacement, afterLineCount is `0` and the `@@` hunk header is generated as `+0,0`:                                                                                                                                                                                                                                                                                                                       
```
  // GradleLintPatchAction.groovy line 260                                                                                                                                                                                                                                                                                                                                                                                                  
  +${afterLineCount == 0 ? 0 : firstLineOfContext},$afterLineCount
```
`+0,0` is a valid convention for complete file deletion (@@ -1,N +0,0 @@), where "0 lines at position 0" means the file is empty.
For a partial deletion (@@ -184,3 +0,0 @@), it is semantically wrong — the + position should be firstLineOfContext, not 0.                                                                                                                                                                                
   
 JGit's ApplyCommand handles +0,0 correctly when context lines are present in the patch (it anchors on them and ignores the +l value). When there are no context lines, JGit falls back to the +l value to locate the hunk; l=0 treats the entire file as the target region, clearing it.                                                                                                                                  
                  
Issue #2. Context lines are dropped when the deleted block is preceded only by blank lines.                                                                                                                                                                                                                                                                                                                                                      
                  
GradleLintPatchAction takes 3 lines before the fix as before-context, then strips leading blank ones via dropWhile:                                                                                                                                                                                                                                                                                                                       
```
  // line 177                                                                                                                                                                                                                                                                                                                                                                                                                               
  .dropWhile { String line -> j == 0 && StringUtils.isBlank(line) }
```
When all 3 candidate context lines are blank (e.g. multiple blank lines separating the last block from the rest of the file), dropWhile strips them all. The patch ends up with zero context lines, exposing the +0,0 bug above.